### PR TITLE
Cache build deps in ECR

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,15 +1,30 @@
+build-env: &build-env
+  plugins:
+    - seek-oss/docker-ecr-cache#v1.1.0:
+        target: build-deps
+        cache-on:
+          - Cargo.lock
+    - docker#v2.0.0
+
 steps:
   - label: ":cargo: Build & Test"
     command:
-      - /bin/sh -c "cargo build &&
-                    cargo test &&
-                    ./.buildkite/cross-i686.sh &&
-                    ./driver/tests/integration/run.sh target/debug/arret"
-    plugins:
-      - docker-compose#v2.6.0:
-          run: full-compiler
+      - cargo check --release
+      - cargo build
+      - cargo test
+      - ./.buildkite/cross-i686.sh
+      - ./driver/tests/integration/run.sh target/debug/arret
+    <<: *build-env
 
   - wait
+
+  - label: ":rust: Build (Rust Beta)"
+    branches: "master"
+    command:
+      - rustup default beta
+      - cargo check
+      - cargo check --release
+    <<: *build-env
 
   - label: ":rocket: Push REPL Image"
     branches: "master"
@@ -22,11 +37,3 @@ steps:
             repl:etaoins/arret:repl
           env:
             - BUILDKITE_COMMIT
-
-  - label: ":rust: Build (Rust Beta)"
-    branches: "master"
-    plugins:
-      - docker-compose#v2.6.0:
-          build: full-compiler
-          args:
-            - rust_toolchain=beta

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM debian:buster AS full-compiler
-
-ARG rust_toolchain=stable
+FROM debian:buster AS build-deps
 
 RUN \
   apt-get update && \
@@ -10,12 +8,17 @@ RUN \
 # Use Clang as it understands LLVM target triples
 RUN update-alternatives --install /usr/bin/cc cc /usr/bin/clang-7 100
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $rust_toolchain
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH "/root/.cargo/bin:${PATH}"
 
 ADD . /opt/arret
 WORKDIR /opt/arret
 
+RUN cargo fetch
+
+###
+
+FROM build-deps as full-compiler
 RUN cargo build --release
 
 ###

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,8 @@
 version: '3.4'
 services:
-  full-compiler:
-    build:
-      context: .
-      target: full-compiler
-      args:
-        - rust_toolchain=stable
-
   repl:
     build:
       context: .
       target: repl
       args:
-        - rust_toolchain=stable
         - vcs_ref=${BUILDKITE_COMMIT}


### PR DESCRIPTION
This uses a modified `docker-ecr-cache` Buildkite plugin to keep our deps in ECR. This is cached off of the `Cargo.lock` hash.