### PR TITLE
Add LLVM assertions test

### DIFF
--- a/.buildkite/llvm-assert.Dockerfile
+++ b/.buildkite/llvm-assert.Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:18.04 AS build-env
+
+ARG LLVM_MAJOR=7
+ARG LLVM_VERSION=7.0.1
+ARG LLVM_ROOT=/opt/llvm-${LLVM_MAJOR}
+
+RUN apt-get update && \
+  apt-get -y install build-essential curl cmake ninja-build python && \
+  apt-get clean
+
+WORKDIR /usr/src
+RUN curl http://releases.llvm.org/${LLVM_VERSION}/llvm-${LLVM_VERSION}.src.tar.xz -sS | \
+  tar -Jx --no-same-owner
+
+WORKDIR /usr/src/llvm-build
+
+# We need to be careful to use less than 4GiB on our build agents
+RUN cmake \
+  -GNinja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=${LLVM_ROOT} \
+  -DLLVM_TARGETS_TO_BUILD=X86 \
+  -DLLVM_USE_LINKER=gold \
+  ../llvm-${LLVM_VERSION}.src
+
+RUN ninja install && rm -Rf /usr/src/llvm-build
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.33.0
+
+ENV PATH "/root/.cargo/bin:${PATH}"
+ENV LLVM_SYS_70_PREFIX "${LLVM_ROOT}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,13 +1,13 @@
 cached-ecr-build-env: &cached-ecr-build-env
   plugins:
-    - seek-oss/docker-ecr-cache#v1.1.0:
+    - seek-oss/docker-ecr-cache#v1.1.1:
         target: build-env
         cache-on:
           - Cargo.lock
     - docker#v2.0.0
 
 steps:
-  - label: ":cargo: Build & Test"
+  - label: ":cargo: Test x86-64 & i686"
     command:
       - cargo check --release
       - cargo build
@@ -26,9 +26,20 @@ steps:
     agents:
       queue: arm64
 
+  - label: ":cop: Test with LLVM Assertions"
+    branches: '!master'
+    command:
+      - cargo build
+      - cargo test
+      - ./driver/tests/integration/run.sh target/debug/arret
+    plugins:
+      - seek-oss/docker-ecr-cache#v1.1.1:
+          dockerfile: ./.buildkite/llvm-assert.Dockerfile
+      - docker#v2.0.0
+
   - wait
 
-  - label: ":rust: Build (Rust Beta)"
+  - label: ":rust: Check (Rust Beta)"
     branches: "master"
     command:
       - rustup default beta
@@ -47,3 +58,4 @@ steps:
             repl:etaoins/arret:repl
           env:
             - BUILDKITE_COMMIT
+


### PR DESCRIPTION
This is an extremely slow test, especially if the Docker build image needs to be regenerated. Make this an optional unblockable step for branch builds