### PR TITLE
Only run main tests on master

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,6 +17,7 @@ steps:
     <<: *cached-ecr-build-env
 
   - label: ":muscle: Test ARM64"
+    branches: '!master'
     command: bash -c "cargo build &&
                       cargo test &&
                       ./driver/tests/integration/run.sh target/debug/arret"


### PR DESCRIPTION
We now have branch protections to make sure PRs are up-to-date before merging. This means the code should already be tested. We also can't autoscale the ARM64 queue so we should use it wisely. Leave the main tests in for paranoia.