### PR TITLE
Basic arithmetic support

### DIFF
--- a/compiler/tests/eval-pass/math.arret
+++ b/compiler/tests/eval-pass/math.arret
@@ -1,0 +1,66 @@
+(import [stdlib base])
+(import [stdlib test])
+
+(defn test-add ()
+  (assert-eq 0 (+))
+  (assert-eq 4 (+ 4))
+
+  (assert-eq 7 (+ 4 3))
+  (assert-eq 7.0 (+ 4.0 3))
+  (assert-eq 7.0 (+ 4 3.0))
+  (assert-eq 7.0 (+ 4.0 3.0))
+
+  (assert-eq true (nan? (+ ##NaN)))
+  (assert-eq true (nan? (+ 1.0 ##NaN)))
+
+  ())
+
+(defn test-mul ()
+  (assert-eq 1 (*))
+  (assert-eq 4 (* 4))
+
+  (assert-eq 12 (* 4 3))
+  (assert-eq 12.0 (* 4.0 3))
+  (assert-eq 12.0 (* 4 3.0))
+  (assert-eq 12.0 (* 4.0 3.0))
+
+  (assert-eq true (nan? (* ##NaN)))
+  (assert-eq true (nan? (* 1.0 ##NaN)))
+
+  ())
+
+(defn test-sub ()
+  (assert-eq -3.0 (- 3.0))
+  (assert-eq 3 (- -3))
+
+  (assert-eq 4 (- 7 3))
+  (assert-eq 4.0 (- 7 3.0))
+  (assert-eq 4.0 (- 7.0 3))
+  (assert-eq 4.0 (- 7.0 3.0))
+
+  (assert-eq true (nan? (- ##NaN)))
+  (assert-eq true (nan? (- 1.0 ##NaN)))
+
+  ())
+
+(defn test-div ()
+  (assert-eq 1.0 (/ 1))
+  (assert-eq 1.0 (/ 1.0))
+
+  (assert-eq 0.5 (/ 2))
+  (assert-eq 0.5 (/ 2.0))
+
+  (assert-eq 0.25 (/ 1 2 2))
+
+  (assert-eq true (nan? (/ ##NaN)))
+  (assert-eq true (nan? (/ 1.0 ##NaN)))
+
+  ())
+
+(defn main! () ->! ()
+  (test-add)
+  (test-mul)
+  (test-sub)
+  (test-div)
+
+  ())

--- a/compiler/tests/eval-pass/number.arret
+++ b/compiler/tests/eval-pass/number.arret
@@ -11,6 +11,13 @@
   (assert-eq false (zero? ##Inf))
   (assert-eq false (zero? ##-Inf)))
 
+(defn test-nan? ()
+  (assert-eq false (nan? 10.0))
+  (assert-eq true (nan? ##NaN))
+  (assert-eq false (nan? ##Inf))
+  (assert-eq false (nan? ##-Inf)))
+
 (defn main! () ->! ()
   (test-zero?)
+  (test-nan?)
   ())

--- a/runtime/boxed/mod.rs
+++ b/runtime/boxed/mod.rs
@@ -395,6 +395,15 @@ define_tagged_union!(Num, NumSubtype, NumMember, as_num_ref, {
     Float
 });
 
+impl Num {
+    pub fn as_f64(&self) -> f64 {
+        match self.as_subtype() {
+            NumSubtype::Int(int_ref) => int_ref.value() as f64,
+            NumSubtype::Float(float_ref) => float_ref.value(),
+        }
+    }
+}
+
 define_tagged_union!(Bool, BoolSubtype, BoolMember, as_bool_ref, { True, False });
 
 impl Bool {

--- a/runtime/boxed/types/float.rs
+++ b/runtime/boxed/types/float.rs
@@ -1,7 +1,8 @@
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
-use crate::boxed::{AllocType, BoxSize, ConstructableFrom, DirectTagged, Header};
+use crate::boxed::refs::Gc;
+use crate::boxed::{AllocType, BoxSize, ConstructableFrom, DirectTagged, Header, Num};
 use crate::intern::Interner;
 
 #[repr(C, align(16))]
@@ -33,6 +34,10 @@ impl Float {
 
     pub fn value(&self) -> f64 {
         self.value
+    }
+
+    pub fn as_num(&self) -> Gc<Num> {
+        unsafe { Gc::new(&*(self as *const _ as *const Num)) }
     }
 }
 

--- a/runtime/boxed/types/int.rs
+++ b/runtime/boxed/types/int.rs
@@ -1,7 +1,8 @@
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
-use crate::boxed::{AllocType, BoxSize, ConstructableFrom, DirectTagged, Header};
+use crate::boxed::refs::Gc;
+use crate::boxed::{AllocType, BoxSize, ConstructableFrom, DirectTagged, Header, Num};
 use crate::intern::Interner;
 
 #[repr(C, align(16))]
@@ -33,6 +34,10 @@ impl Int {
 
     pub fn value(&self) -> i64 {
         self.value
+    }
+
+    pub fn as_num(&self) -> Gc<Num> {
+        unsafe { Gc::new(&*(self as *const _ as *const Num)) }
     }
 }
 

--- a/stdlib/arret/base.arret
+++ b/stdlib/arret/base.arret
@@ -6,7 +6,7 @@
         sym? bool? num? int? float? char? list? vector? set? map? fn? nil?)
 
 (import [stdlib rust])
-(export length panic print! println! exit! cons map filter concat member?)
+(export length panic print! println! exit! cons map filter concat member? nan? + * - /)
 
 (export defn)
 (defmacro defn (macro-rules

--- a/stdlib/rust/lib.rs
+++ b/stdlib/rust/lib.rs
@@ -10,8 +10,16 @@ use crate::pretty_print::pretty_print;
 
 pub mod list;
 use crate::list::*;
+
+pub mod math;
+use crate::math::*;
+
+pub mod number;
+use crate::number::*;
+
 pub mod testing;
 use crate::testing::*;
+
 pub mod write;
 use crate::write::*;
 
@@ -51,6 +59,13 @@ define_rust_module!(ARRET_STDLIB_RUST_EXPORTS, {
     "cons" => stdlib_cons,
     "concat" => stdlib_concat,
     "member?" => stdlib_member_p,
+
+    "nan?" => stdlib_nan_p,
+    "+" => stdlib_add,
+    "*" => stdlib_mul,
+    "-" => stdlib_sub,
+    "/" => stdlib_div,
+
     "black-box" => stdlib_black_box,
     "black-box!" => stdlib_black_box_impure,
     "heap-alloc-count" => stdlib_heap_alloc_count,

--- a/stdlib/rust/math.rs
+++ b/stdlib/rust/math.rs
@@ -1,0 +1,116 @@
+use runtime::binding::*;
+
+use runtime::boxed;
+use runtime::boxed::prelude::*;
+use runtime::boxed::refs::Gc;
+use runtime::task::Task;
+
+use rfi_derive;
+
+fn fold_float_op<FR>(
+    task: &mut Task,
+    operands_iter: impl ExactSizeIterator<Item = Gc<boxed::Num>>,
+    initial_value: f64,
+    float_reduce: FR,
+) -> Gc<boxed::Float>
+where
+    FR: Fn(f64, f64) -> f64,
+{
+    let mut float_acc = initial_value;
+
+    for operand in operands_iter {
+        match operand.as_subtype() {
+            boxed::NumSubtype::Int(int_ref) => {
+                float_acc = float_reduce(float_acc, int_ref.value() as f64);
+            }
+            boxed::NumSubtype::Float(float_ref) => {
+                // Convert to float and break
+                float_acc = float_reduce(float_acc, float_ref.value());
+            }
+        }
+    }
+
+    boxed::Float::new(task, float_acc)
+}
+
+fn fold_num_op<IR, FR>(
+    task: &mut Task,
+    mut operands_iter: impl ExactSizeIterator<Item = Gc<boxed::Num>>,
+    initial_value: i64,
+    int_reduce: IR,
+    float_reduce: FR,
+) -> Gc<boxed::Num>
+where
+    IR: Fn(i64, i64) -> i64,
+    FR: Fn(f64, f64) -> f64,
+{
+    // Accumulate as an integer for as long as possible
+    let mut int_acc = initial_value;
+
+    while let Some(operand) = operands_iter.next() {
+        match operand.as_subtype() {
+            boxed::NumSubtype::Int(int_ref) => {
+                int_acc = int_reduce(int_acc, int_ref.value());
+            }
+            boxed::NumSubtype::Float(float_ref) => {
+                // Switch to float
+                let float_acc = float_reduce(int_acc as f64, float_ref.value());
+                return fold_float_op(task, operands_iter, float_acc, float_reduce).as_num();
+            }
+        }
+    }
+
+    boxed::Int::new(task, int_acc).as_num()
+}
+
+#[rfi_derive::rust_fun("(All #{[N Num]} N ... -> N)")]
+pub fn stdlib_add(task: &mut Task, operands: Gc<boxed::List<boxed::Num>>) -> Gc<boxed::Num> {
+    use std::ops::Add;
+    fold_num_op(task, operands.iter(), 0, i64::add, f64::add)
+}
+
+#[rfi_derive::rust_fun("(All #{[N Num]} N ... -> N)")]
+pub fn stdlib_mul(task: &mut Task, operands: Gc<boxed::List<boxed::Num>>) -> Gc<boxed::Num> {
+    use std::ops::Mul;
+    fold_num_op(task, operands.iter(), 1, i64::mul, f64::mul)
+}
+
+#[rfi_derive::rust_fun("(All #{[N Num]} N N ... -> N)")]
+pub fn stdlib_sub(
+    task: &mut Task,
+    initial_num: Gc<boxed::Num>,
+    rest: Gc<boxed::List<boxed::Num>>,
+) -> Gc<boxed::Num> {
+    use std::ops::Sub;
+
+    match initial_num.as_subtype() {
+        boxed::NumSubtype::Int(int_ref) => {
+            if rest.is_empty() {
+                boxed::Int::new(task, -int_ref.value()).as_num()
+            } else {
+                fold_num_op(task, rest.iter(), int_ref.value(), i64::sub, f64::sub)
+            }
+        }
+        boxed::NumSubtype::Float(float_ref) => {
+            if rest.is_empty() {
+                boxed::Float::new(task, -float_ref.value()).as_num()
+            } else {
+                fold_float_op(task, rest.iter(), float_ref.value(), f64::sub).as_num()
+            }
+        }
+    }
+}
+
+#[rfi_derive::rust_fun("(Num Num ... -> Float)")]
+pub fn stdlib_div(initial_num: Gc<boxed::Num>, rest: Gc<boxed::List<boxed::Num>>) -> f64 {
+    if rest.is_empty() {
+        initial_num.as_f64().recip()
+    } else {
+        let mut acc = initial_num.as_f64();
+        for operand in rest.iter() {
+            acc /= operand.as_f64()
+        }
+
+        acc
+    }
+}

--- a/stdlib/rust/number.rs
+++ b/stdlib/rust/number.rs
@@ -1,0 +1,8 @@
+use runtime::binding::*;
+
+use rfi_derive;
+
+#[rfi_derive::rust_fun("(Float -> Bool)")]
+pub fn stdlib_nan_p(float: f64) -> bool {
+    float.is_nan()
+}


### PR DESCRIPTION
This implements the basic Lisp-y, `+`, `*`, `-` and `*` in the stdlib. It also adds `nan?` to make testing easier.

These aren't treated as intrinsics so we will always generate an expensive library call for non-constant values.