### PR TITLE
Add threading, fix ret evidence

### DIFF
--- a/compiler/tests/eval-pass/list.arret
+++ b/compiler/tests/eval-pass/list.arret
@@ -51,6 +51,14 @@
   (assert-eq false (member? 1 '(4 5 6)))
   (assert-eq false (member? ##NaN '(1 2 ##NaN))))
 
+(defn test-threading ()
+  (assert-eq '(3 5 7 9)
+    (->> '(0 1 2 3 4)
+      ; Make sure these are run in the correct order
+      (map (fn (x) (* x 2)))
+      (filter (fn (x) (not (zero? x))))
+      (map (fn (x) (+ x 1))))))
+
 (defn main! () ->! ()
   (test-length)
   (test-first-rest)
@@ -59,5 +67,6 @@
   (test-filter)
   (test-concat)
   (test-member)
+  (test-threading)
 
   ())

--- a/stdlib/arret/base.arret
+++ b/stdlib/arret/base.arret
@@ -72,3 +72,10 @@
   (if (int? n)
     (= n 0)
     (= n 0.0)))
+
+(export ->>)
+(defmacro ->> (macro-rules
+  [(initial) initial]
+  [(initial (first-fn args ...) rest ...)
+    (->> (first-fn args ... initial) rest ...)]
+))


### PR DESCRIPTION
- Don't use a function's return type as evidence for its parameter values. This doesn't do what we think it does because the return value is restricting the parameter types (think intersection) while the parameters are expanding them (think unification).

  Removing the return type evidence doesn't seem to make any tests fail so take it out entirely.

- Add an implementation of the `->>` macro