### PR TITLE
Support for anon fun literals

### DIFF
--- a/compiler/reporting.rs
+++ b/compiler/reporting.rs
@@ -202,6 +202,9 @@ impl Reportable for syntax::error::Error {
             ErrorKind::InvalidFloat => "unable to parse float".to_owned(),
             ErrorKind::UnexpectedChar(c) => format!("unexpected `{}`", c),
             ErrorKind::UnevenMap => "map literal must have an even number of values".to_owned(),
+            ErrorKind::InvalidArgLiteral => {
+                "arg literal must be `%`, `%{integer}` or `%...`".to_owned()
+            }
         }
     }
 

--- a/compiler/tests/eval-pass/list.arret
+++ b/compiler/tests/eval-pass/list.arret
@@ -20,10 +20,10 @@
 (defn test-map ()
   (assert-eq '() (map (fn (x) x) '()))
   (assert-eq '(1 2 3 4 5) (map (fn (x) x) '(1 2 3 4 5)))
-  (assert-eq '(0 1 2 3) (map (fn (x) (length x)) '(() (1) (1 2) (1 2 3))))
+  (assert-eq '(0 1 2 3) (map #(length %) '(() (1) (1 2) (1 2 3))))
   (assert-eq '(4 4 4) (map (fn (x) 4) '(1 2 3)))
   (assert-eq '(() () ()) (map (fn (x) ()) '(1 2 3)))
-  (assert-eq '(true false true) (map (fn (x) (= x "yes")) '("yes" "no" "yes")))
+  (assert-eq '(true false true) (map #(= % "yes") '("yes" "no" "yes")))
 
   ; This should be safe because `panic` won't be called
   (map panic '()))
@@ -37,7 +37,7 @@
 
   (assert-eq '(true true) (filter (fn (x) x) '(true false true false)))
 
-  (assert-eq '(3) (filter (fn (x) (= x 3)) '(1 2 3 4))))
+  (assert-eq '(3) (filter #(= % 3) '(1 2 3 4))))
 
 (defn test-concat ()
   (assert-eq '() (concat))
@@ -55,9 +55,9 @@
   (assert-eq '(3 5 7 9)
     (->> '(0 1 2 3 4)
       ; Make sure these are run in the correct order
-      (map (fn (x) (* x 2)))
-      (filter (fn (x) (not (zero? x))))
-      (map (fn (x) (+ x 1))))))
+      (map #(* % 2))
+      (filter #(not (zero? %)))
+      (map #(+ % 1)))))
 
 (defn main! () ->! ()
   (test-length)

--- a/syntax/anon_fun.rs
+++ b/syntax/anon_fun.rs
@@ -1,0 +1,212 @@
+use crate::datum::Datum;
+use crate::error::{Error, ErrorKind, Result};
+use crate::span::Span;
+
+struct FoundArity {
+    fixed_args: u8,
+    has_rest: bool,
+}
+
+/// Visits all arg literals replacing `%` with `%1` and tracking our arity
+fn visit_arg_literals(found_arity: &mut FoundArity, datum: Datum) -> Result<Datum> {
+    match datum {
+        Datum::Sym(span, name) => {
+            if name.starts_with('%') {
+                match &name[1..] {
+                    "" => {
+                        // We need to rewrite this to %1 in case it's also referred to by that name
+                        found_arity.fixed_args = std::cmp::max(found_arity.fixed_args, 1);
+                        Ok(Datum::Sym(span, "%1".into()))
+                    }
+                    "..." => {
+                        found_arity.has_rest = true;
+                        Ok(Datum::Sym(span, name))
+                    }
+                    other => other
+                        .parse::<u8>()
+                        .map(|parsed_number| {
+                            found_arity.fixed_args =
+                                std::cmp::max(found_arity.fixed_args, parsed_number);
+                            Datum::Sym(span, name)
+                        })
+                        .map_err(|_| Error::new(span, ErrorKind::InvalidArgLiteral)),
+                }
+            } else {
+                Ok(Datum::Sym(span, name))
+            }
+        }
+        Datum::List(span, content) => {
+            let replaced_content = content
+                .into_vec()
+                .into_iter()
+                .map(|body_datum| visit_arg_literals(found_arity, body_datum))
+                .collect::<Result<Vec<Datum>>>()?;
+
+            Ok(Datum::List(span, replaced_content.into()))
+        }
+        other => Ok(other),
+    }
+}
+
+/// Converts body data from a `#()` reader macro in to an anonymous function
+pub fn convert_anon_fun(outer_span: Span, body_data: impl Iterator<Item = Datum>) -> Result<Datum> {
+    use std::iter;
+
+    let mut found_arity = FoundArity {
+        fixed_args: 0,
+        has_rest: false,
+    };
+
+    let replaced_body = body_data
+        .map(|body_datum| visit_arg_literals(&mut found_arity, body_datum))
+        .collect::<Result<Vec<Datum>>>()?;
+
+    let mut param_list: Vec<Datum> = (0..found_arity.fixed_args)
+        .map(|param_index| {
+            let param_ordinal = param_index + 1;
+            Datum::Sym(outer_span, format!("%{}", param_ordinal).into())
+        })
+        .collect();
+
+    if found_arity.has_rest {
+        param_list.extend(
+            iter::once(Datum::Sym(outer_span, "%...".into()))
+                .chain(iter::once(Datum::Sym(outer_span, "...".into()))),
+        );
+    }
+
+    let expanded_fun = vec![
+        Datum::Sym(outer_span, "fn".into()),
+        Datum::List(outer_span, param_list.into()),
+        Datum::List(outer_span, replaced_body.into()),
+    ];
+
+    Ok(Datum::List(outer_span, expanded_fun.into()))
+}
+
+/////////
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::parser::data_from_str;
+    use crate::span::{t2s, EMPTY_SPAN};
+
+    #[test]
+    fn empty_fun() {
+        let body_data = data_from_str("").unwrap();
+
+        let expected = Datum::List(
+            EMPTY_SPAN,
+            Box::new([
+                Datum::Sym(EMPTY_SPAN, "fn".into()),
+                Datum::List(EMPTY_SPAN, Box::new([])),
+                Datum::List(EMPTY_SPAN, Box::new([])),
+            ]),
+        );
+
+        assert_eq!(
+            expected,
+            convert_anon_fun(EMPTY_SPAN, body_data.into_iter()).unwrap()
+        );
+    }
+
+    #[test]
+    fn one_arg_fun() {
+        let j = "%";
+        let t = "^";
+
+        let body_data = data_from_str(j).unwrap();
+
+        let expected = Datum::List(
+            EMPTY_SPAN,
+            Box::new([
+                Datum::Sym(EMPTY_SPAN, "fn".into()),
+                Datum::List(EMPTY_SPAN, Box::new([Datum::Sym(EMPTY_SPAN, "%1".into())])),
+                Datum::List(
+                    EMPTY_SPAN,
+                    Box::new([
+                        // This is converted to %1
+                        Datum::Sym(t2s(t), "%1".into()),
+                    ]),
+                ),
+            ]),
+        );
+
+        assert_eq!(
+            expected,
+            convert_anon_fun(EMPTY_SPAN, body_data.into_iter()).unwrap()
+        );
+    }
+
+    #[test]
+    fn two_arg_fun() {
+        let j = "%1 %2";
+        let t = "^^   ";
+        let u = "   ^^";
+
+        let body_data = data_from_str(j).unwrap();
+
+        let expected = Datum::List(
+            EMPTY_SPAN,
+            Box::new([
+                Datum::Sym(EMPTY_SPAN, "fn".into()),
+                Datum::List(
+                    EMPTY_SPAN,
+                    Box::new([
+                        Datum::Sym(EMPTY_SPAN, "%1".into()),
+                        Datum::Sym(EMPTY_SPAN, "%2".into()),
+                    ]),
+                ),
+                Datum::List(
+                    EMPTY_SPAN,
+                    Box::new([
+                        Datum::Sym(t2s(t), "%1".into()),
+                        Datum::Sym(t2s(u), "%2".into()),
+                    ]),
+                ),
+            ]),
+        );
+
+        assert_eq!(
+            expected,
+            convert_anon_fun(EMPTY_SPAN, body_data.into_iter()).unwrap()
+        );
+    }
+
+    #[test]
+    fn rest_fun() {
+        let j = "%1 %...";
+        let t = "^^     ";
+        let u = "   ^^^^";
+
+        let body_data = data_from_str(j).unwrap();
+
+        let expected = Datum::List(
+            EMPTY_SPAN,
+            Box::new([
+                Datum::Sym(EMPTY_SPAN, "fn".into()),
+                Datum::List(
+                    EMPTY_SPAN,
+                    Box::new([
+                        Datum::Sym(EMPTY_SPAN, "%1".into()),
+                        Datum::Sym(EMPTY_SPAN, "%...".into()),
+                        Datum::Sym(EMPTY_SPAN, "...".into()),
+                    ]),
+                ),
+                Datum::List(
+                    EMPTY_SPAN,
+                    Box::new([
+                        Datum::Sym(t2s(t), "%1".into()),
+                        Datum::Sym(t2s(u), "%...".into()),
+                    ]),
+                ),
+            ]),
+        );
+
+        assert_eq!(
+            expected,
+            convert_anon_fun(EMPTY_SPAN, body_data.into_iter()).unwrap()
+        );
+    }
+}

--- a/syntax/error.rs
+++ b/syntax/error.rs
@@ -36,6 +36,7 @@ pub enum ErrorKind {
     InvalidFloat,
     UnexpectedChar(char),
     UnevenMap,
+    InvalidArgLiteral,
 }
 
 pub type Result<T> = result::Result<T, Error>;

--- a/syntax/lib.rs
+++ b/syntax/lib.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::all)]
 #![warn(rust_2018_idioms)]
 
+mod anon_fun;
 pub mod datum;
 pub mod error;
 pub mod parser;


### PR DESCRIPTION
This is a near direct copy from Clojure except `%...` replaces `%&` due to our different rest syntax.