### PR TITLE
Make `(/)` only accept floats

### DIFF
--- a/compiler/tests/eval-pass/math.arret
+++ b/compiler/tests/eval-pass/math.arret
@@ -44,13 +44,9 @@
   ())
 
 (defn test-div ()
-  (assert-eq 1.0 (/ 1))
   (assert-eq 1.0 (/ 1.0))
-
-  (assert-eq 0.5 (/ 2))
   (assert-eq 0.5 (/ 2.0))
-
-  (assert-eq 0.25 (/ 1 2 2))
+  (assert-eq 0.25 (/ 1.0 2.0 2.0))
 
   (assert-eq true (nan? (/ ##NaN)))
   (assert-eq true (nan? (/ 1.0 ##NaN)))

--- a/runtime/boxed/mod.rs
+++ b/runtime/boxed/mod.rs
@@ -396,15 +396,6 @@ define_tagged_union!(Num, NumSubtype, NumMember, as_num_ref, {
     Float
 });
 
-impl Num {
-    pub fn as_f64(&self) -> f64 {
-        match self.as_subtype() {
-            NumSubtype::Int(int_ref) => int_ref.value() as f64,
-            NumSubtype::Float(float_ref) => float_ref.value(),
-        }
-    }
-}
-
 define_tagged_union!(Bool, BoolSubtype, BoolMember, as_bool_ref, { True, False });
 
 impl Bool {

--- a/stdlib/rust/math.rs
+++ b/stdlib/rust/math.rs
@@ -101,14 +101,14 @@ pub fn stdlib_sub(
     }
 }
 
-#[rfi_derive::rust_fun("(Num Num ... -> Float)")]
-pub fn stdlib_div(initial_num: Gc<boxed::Num>, rest: Gc<boxed::List<boxed::Num>>) -> f64 {
+#[rfi_derive::rust_fun("(Float Float ... -> Float)")]
+pub fn stdlib_div(initial_float: f64, rest: Gc<boxed::List<boxed::Float>>) -> f64 {
     if rest.is_empty() {
-        initial_num.as_f64().recip()
+        initial_float.recip()
     } else {
-        let mut acc = initial_num.as_f64();
+        let mut acc = initial_float;
         for operand in rest.iter() {
-            acc /= operand.as_f64()
+            acc /= operand.value()
         }
 
         acc


### PR DESCRIPTION
This always does floating point arithmetic. We should make this obvious by forcing the caller to convert.