### PR TITLE
Remove unused impl lifetime

### DIFF
--- a/compiler/mir/value/list.rs
+++ b/compiler/mir/value/list.rs
@@ -30,7 +30,7 @@ pub struct ListIterator {
     rest: Option<Value>,
 }
 
-impl<'list> ListIterator {
+impl ListIterator {
     pub fn new(value: Value) -> ListIterator {
         ListIterator {
             fixed: Vec::new().into_iter(),


### PR DESCRIPTION
Nothing catches this as a warning at the moment.