### PR TITLE
Intrinsics for no-op (float) and (int)

### DIFF
--- a/compiler/mir/intrinsic/mod.rs
+++ b/compiler/mir/intrinsic/mod.rs
@@ -1,6 +1,7 @@
 mod list;
 mod math;
 mod testing;
+mod number;
 
 use syntax::span::Span;
 
@@ -35,5 +36,7 @@ define_intrinsics! {
     "cons" => list::cons,
     "fn-op-categories" => testing::fn_op_categories,
     "+" => math::add,
-    "*" => math::mul
+    "*" => math::mul,
+    "int" => number::int,
+    "float" => number::float
 }

--- a/compiler/mir/intrinsic/number.rs
+++ b/compiler/mir/intrinsic/number.rs
@@ -1,0 +1,43 @@
+use syntax::span::Span;
+
+use runtime::boxed::TypeTag;
+
+use crate::mir::builder::Builder;
+use crate::mir::error::Result;
+use crate::mir::eval_hir::EvalHirCtx;
+use crate::mir::value::types::possible_type_tags_for_value;
+use crate::mir::Value;
+
+pub fn int(
+    _ehx: &mut EvalHirCtx,
+    b: &mut Option<Builder>,
+    span: Span,
+    arg_list_value: &Value,
+) -> Result<Option<Value>> {
+    let value = arg_list_value.list_iter().next_unchecked(b, span);
+
+    Ok(
+        if possible_type_tags_for_value(&value) == TypeTag::Int.into() {
+            Some(value)
+        } else {
+            None
+        },
+    )
+}
+
+pub fn float(
+    _ehx: &mut EvalHirCtx,
+    b: &mut Option<Builder>,
+    span: Span,
+    arg_list_value: &Value,
+) -> Result<Option<Value>> {
+    let value = arg_list_value.list_iter().next_unchecked(b, span);
+
+    Ok(
+        if possible_type_tags_for_value(&value) == TypeTag::Float.into() {
+            Some(value)
+        } else {
+            None
+        },
+    )
+}

--- a/compiler/tests/optimise/number.arret
+++ b/compiler/tests/optimise/number.arret
@@ -1,0 +1,13 @@
+(import [stdlib base])
+(import [stdlib test])
+
+(defn main! ()
+  ; This should be the identity function for `Int`
+  (assert-fn-doesnt-contain-op :call (fn ([i Int])
+    (int i)))
+
+  ; This should be the identity function for `Float`
+  (assert-fn-doesnt-contain-op :call (fn ([f Float])
+    (float f)))
+
+  ())


### PR DESCRIPTION
These could be used e.g. in a function that's generic on the input type and converts it to a known number type.