### PR TITLE
Add intrinsic (float) for ints

### DIFF
--- a/compiler/codegen/op_gen.rs
+++ b/compiler/codegen/op_gen.rs
@@ -494,6 +494,18 @@ fn gen_op(
 
                 fcx.regs.insert(*reg, llvm_i64);
             }
+            OpKind::Int64ToFloat(reg, int64_reg) => {
+                let llvm_i64 = fcx.regs[int64_reg];
+
+                let llvm_double = LLVMBuildSIToFP(
+                    fcx.builder,
+                    llvm_i64,
+                    LLVMDoubleTypeInContext(tcx.llx),
+                    "i64_as_double\0".as_ptr() as *const _,
+                );
+
+                fcx.regs.insert(*reg, llvm_double);
+            }
             OpKind::MakeCallback(
                 reg,
                 MakeCallbackOp {

--- a/compiler/mir/eval_hir.rs
+++ b/compiler/mir/eval_hir.rs
@@ -598,6 +598,14 @@ impl EvalHirCtx {
         }
 
         if let Some(b) = b {
+            if let Some(intrinsic_name) = rust_fun.intrinsic_name() {
+                if let Some(value) =
+                    intrinsic::try_build(self, b, span, intrinsic_name, &arg_list_value)?
+                {
+                    return Ok(value);
+                }
+            }
+
             build_rust_fun_app(self, b, span, ret_ty, rust_fun, call_purity, arg_list_value)
         } else {
             panic!("Need builder for non-const function application");

--- a/compiler/mir/intrinsic/math.rs
+++ b/compiler/mir/intrinsic/math.rs
@@ -8,7 +8,7 @@ use crate::mir::Value;
 
 pub fn add(
     _ehx: &mut EvalHirCtx,
-    b: &mut Option<Builder>,
+    b: &mut Builder,
     span: Span,
     arg_list_value: &Value,
 ) -> Result<Option<Value>> {
@@ -21,7 +21,7 @@ pub fn add(
 
 pub fn mul(
     _ehx: &mut EvalHirCtx,
-    b: &mut Option<Builder>,
+    b: &mut Builder,
     span: Span,
     arg_list_value: &Value,
 ) -> Result<Option<Value>> {

--- a/compiler/mir/intrinsic/mod.rs
+++ b/compiler/mir/intrinsic/mod.rs
@@ -1,7 +1,7 @@
 mod list;
 mod math;
-mod testing;
 mod number;
+mod testing;
 
 use syntax::span::Span;
 
@@ -10,7 +10,7 @@ use crate::mir::error::Result;
 use crate::mir::eval_hir::EvalHirCtx;
 use crate::mir::Value;
 
-macro_rules! define_intrinsics {
+macro_rules! define_eval_intrinsics {
     ( $($name:expr => $handler:path),* ) => {
         pub fn try_eval(
             ehx: &mut EvalHirCtx,
@@ -31,10 +31,34 @@ macro_rules! define_intrinsics {
     };
 }
 
-define_intrinsics! {
+macro_rules! define_build_intrinsics {
+    ( $($name:expr => $handler:path),* ) => {
+        pub fn try_build(
+            ehx: &mut EvalHirCtx,
+            b: &mut Builder,
+            span: Span,
+            intrinsic_name: &'static str,
+            arg_list_value: &Value,
+        ) -> Result<Option<Value>> {
+            match intrinsic_name {
+                $(
+                    $name => {
+                        $handler(ehx, b, span, arg_list_value)
+                    }
+                ),*
+                _ => Ok(None),
+            }
+        }
+    };
+}
+
+define_eval_intrinsics! {
     "length" => list::length,
     "cons" => list::cons,
-    "fn-op-categories" => testing::fn_op_categories,
+    "fn-op-categories" => testing::fn_op_categories
+}
+
+define_build_intrinsics! {
     "+" => math::add,
     "*" => math::mul,
     "int" => number::int,

--- a/compiler/mir/intrinsic/number.rs
+++ b/compiler/mir/intrinsic/number.rs
@@ -10,7 +10,7 @@ use crate::mir::Value;
 
 pub fn int(
     _ehx: &mut EvalHirCtx,
-    b: &mut Option<Builder>,
+    b: &mut Builder,
     span: Span,
     arg_list_value: &Value,
 ) -> Result<Option<Value>> {
@@ -26,18 +26,27 @@ pub fn int(
 }
 
 pub fn float(
-    _ehx: &mut EvalHirCtx,
-    b: &mut Option<Builder>,
+    ehx: &mut EvalHirCtx,
+    b: &mut Builder,
     span: Span,
     arg_list_value: &Value,
 ) -> Result<Option<Value>> {
     let value = arg_list_value.list_iter().next_unchecked(b, span);
+    let possible_type_tags = possible_type_tags_for_value(&value);
 
-    Ok(
-        if possible_type_tags_for_value(&value) == TypeTag::Float.into() {
-            Some(value)
-        } else {
-            None
-        },
-    )
+    Ok(if possible_type_tags == TypeTag::Float.into() {
+        Some(value)
+    } else if possible_type_tags == TypeTag::Int.into() {
+        use crate::mir::ops::*;
+        use crate::mir::value;
+        use crate::mir::value::build_reg::value_to_reg;
+        use runtime::abitype;
+
+        let int_reg = value_to_reg(ehx, b, span, &value, &abitype::ABIType::Int);
+        let float_reg = b.push_reg(span, OpKind::Int64ToFloat, int_reg.into());
+
+        Some(value::RegValue::new(float_reg, abitype::ABIType::Float).into())
+    } else {
+        None
+    })
 }

--- a/compiler/mir/ops.rs
+++ b/compiler/mir/ops.rs
@@ -171,6 +171,7 @@ pub enum OpKind {
     FloatEqual(RegId, BinaryOp),
     BoxIdentical(RegId, BinaryOp),
     UsizeToInt64(RegId, RegId),
+    Int64ToFloat(RegId, RegId),
 
     Ret(RegId),
     RetVoid,
@@ -237,6 +238,7 @@ impl OpKind {
             | CharEqual(reg_id, _)
             | BoxIdentical(reg_id, _)
             | UsizeToInt64(reg_id, _)
+            | Int64ToFloat(reg_id, _)
             | MakeCallback(reg_id, _) => Some(*reg_id),
             Cond(cond_op) => cond_op.reg_phi.clone().map(|reg_phi| reg_phi.output_reg),
             Ret(_) | RetVoid | Unreachable => None,
@@ -309,6 +311,7 @@ impl OpKind {
             | LoadBoxedCharValue(_, reg_id)
             | LoadBoxedFunThunkClosure(_, reg_id)
             | UsizeToInt64(_, reg_id)
+            | Int64ToFloat(_, reg_id)
             | MakeCallback(
                 _,
                 MakeCallbackOp {
@@ -419,7 +422,8 @@ impl OpKind {
             | IntEqual(_, _)
             | FloatEqual(_, _)
             | CharEqual(_, _)
-            | BoxIdentical(_, _) => OpCategory::RegOp,
+            | BoxIdentical(_, _)
+            | Int64ToFloat(_, _) => OpCategory::RegOp,
 
             Ret(_) | RetVoid => OpCategory::Ret,
 

--- a/compiler/tests/optimise/number.arret
+++ b/compiler/tests/optimise/number.arret
@@ -10,4 +10,8 @@
   (assert-fn-doesnt-contain-op :call (fn ([f Float])
     (float f)))
 
+  ; We can build specific MIR ops for this
+  (assert-fn-doesnt-contain-op :call (fn ([i Int])
+    (float i)))
+
   ())


### PR DESCRIPTION
This also splits or intrinsics in to "eval" and "build" phases. The vast
majority of intrinsics can't do a better than evaluating to a static
constant value at compile time.

Instead of having every "eval" implementation duplicate the constant
case we can have a second phase of intrinsics that runs if we can't
const eval.