### PR TITLE
Basic math intrinsics

### DIFF
--- a/compiler/codegen/op_gen.rs
+++ b/compiler/codegen/op_gen.rs
@@ -412,18 +412,6 @@ fn gen_op(
                 );
                 fcx.regs.insert(*reg, llvm_value);
             }
-            OpKind::Add(reg, BinaryOp { lhs_reg, rhs_reg }) => {
-                let llvm_lhs = fcx.regs[lhs_reg];
-                let llvm_rhs = fcx.regs[rhs_reg];
-
-                let llvm_value = LLVMBuildNUWAdd(
-                    fcx.builder,
-                    llvm_lhs,
-                    llvm_rhs,
-                    "sum\0".as_ptr() as *const _,
-                );
-                fcx.regs.insert(*reg, llvm_value);
-            }
             OpKind::IntEqual(reg, BinaryOp { lhs_reg, rhs_reg })
             | OpKind::CharEqual(reg, BinaryOp { lhs_reg, rhs_reg }) => {
                 let llvm_lhs = fcx.regs[lhs_reg];
@@ -505,6 +493,105 @@ fn gen_op(
                 );
 
                 fcx.regs.insert(*reg, llvm_double);
+            }
+            OpKind::FloatAdd(reg, BinaryOp { lhs_reg, rhs_reg }) => {
+                let llvm_lhs = fcx.regs[lhs_reg];
+                let llvm_rhs = fcx.regs[rhs_reg];
+
+                let llvm_value = LLVMBuildFAdd(
+                    fcx.builder,
+                    llvm_lhs,
+                    llvm_rhs,
+                    "float_sum\0".as_ptr() as *const _,
+                );
+                fcx.regs.insert(*reg, llvm_value);
+            }
+            OpKind::UsizeAdd(reg, BinaryOp { lhs_reg, rhs_reg }) => {
+                let llvm_lhs = fcx.regs[lhs_reg];
+                let llvm_rhs = fcx.regs[rhs_reg];
+
+                let llvm_value = LLVMBuildNUWAdd(
+                    fcx.builder,
+                    llvm_lhs,
+                    llvm_rhs,
+                    "sum\0".as_ptr() as *const _,
+                );
+                fcx.regs.insert(*reg, llvm_value);
+            }
+            OpKind::Int64CheckedAdd(reg, BinaryOp { lhs_reg, rhs_reg }) => {
+                let llvm_lhs = fcx.regs[lhs_reg];
+                let llvm_rhs = fcx.regs[rhs_reg];
+
+                // TODO: Check for overflow
+                let llvm_value = LLVMBuildAdd(
+                    fcx.builder,
+                    llvm_lhs,
+                    llvm_rhs,
+                    "sum\0".as_ptr() as *const _,
+                );
+                fcx.regs.insert(*reg, llvm_value);
+            }
+            OpKind::FloatMul(reg, BinaryOp { lhs_reg, rhs_reg }) => {
+                let llvm_lhs = fcx.regs[lhs_reg];
+                let llvm_rhs = fcx.regs[rhs_reg];
+
+                let llvm_value = LLVMBuildFMul(
+                    fcx.builder,
+                    llvm_lhs,
+                    llvm_rhs,
+                    "float_product\0".as_ptr() as *const _,
+                );
+                fcx.regs.insert(*reg, llvm_value);
+            }
+            OpKind::Int64CheckedMul(reg, BinaryOp { lhs_reg, rhs_reg }) => {
+                let llvm_lhs = fcx.regs[lhs_reg];
+                let llvm_rhs = fcx.regs[rhs_reg];
+
+                // TODO: Check for overflow
+                let llvm_value = LLVMBuildMul(
+                    fcx.builder,
+                    llvm_lhs,
+                    llvm_rhs,
+                    "product\0".as_ptr() as *const _,
+                );
+                fcx.regs.insert(*reg, llvm_value);
+            }
+            OpKind::FloatSub(reg, BinaryOp { lhs_reg, rhs_reg }) => {
+                let llvm_lhs = fcx.regs[lhs_reg];
+                let llvm_rhs = fcx.regs[rhs_reg];
+
+                let llvm_value = LLVMBuildFSub(
+                    fcx.builder,
+                    llvm_lhs,
+                    llvm_rhs,
+                    "float_difference\0".as_ptr() as *const _,
+                );
+                fcx.regs.insert(*reg, llvm_value);
+            }
+            OpKind::Int64CheckedSub(reg, BinaryOp { lhs_reg, rhs_reg }) => {
+                let llvm_lhs = fcx.regs[lhs_reg];
+                let llvm_rhs = fcx.regs[rhs_reg];
+
+                // TODO: Check for overflow
+                let llvm_value = LLVMBuildSub(
+                    fcx.builder,
+                    llvm_lhs,
+                    llvm_rhs,
+                    "difference\0".as_ptr() as *const _,
+                );
+                fcx.regs.insert(*reg, llvm_value);
+            }
+            OpKind::FloatDiv(reg, BinaryOp { lhs_reg, rhs_reg }) => {
+                let llvm_lhs = fcx.regs[lhs_reg];
+                let llvm_rhs = fcx.regs[rhs_reg];
+
+                let llvm_value = LLVMBuildFDiv(
+                    fcx.builder,
+                    llvm_lhs,
+                    llvm_rhs,
+                    "float_quotient\0".as_ptr() as *const _,
+                );
+                fcx.regs.insert(*reg, llvm_value);
             }
             OpKind::MakeCallback(
                 reg,

--- a/compiler/mir/arg_list.rs
+++ b/compiler/mir/arg_list.rs
@@ -74,7 +74,7 @@ pub fn build_save_arg_list_to_regs<'a>(
 ) -> Vec<ops::RegId> {
     use crate::mir::value::build_reg::value_to_reg;
 
-    let mut list_iter = arg_list_value.into_list_iter();
+    let mut list_iter = arg_list_value.into_unsized_list_iter();
 
     let mut arg_regs = vec![];
     for abi_type in fixed_abi_types {

--- a/compiler/mir/eval_hir.rs
+++ b/compiler/mir/eval_hir.rs
@@ -180,7 +180,7 @@ impl EvalHirCtx {
         list: &hir::destruc::List<hir::Inferred>,
         value: Value,
     ) {
-        let mut iter = value.into_list_iter();
+        let mut iter = value.into_unsized_list_iter();
 
         for fixed_destruc in list.fixed() {
             let value = iter.next_unchecked(b, span);
@@ -375,7 +375,7 @@ impl EvalHirCtx {
     ) -> Value {
         use crate::mir::typred::eval_ty_pred;
 
-        let subject_value = arg_list_value.list_iter().next_unchecked(b, span);
+        let subject_value = arg_list_value.unsized_list_iter().next_unchecked(b, span);
         eval_ty_pred(self, b, span, &subject_value, test_ty)
     }
 
@@ -387,7 +387,7 @@ impl EvalHirCtx {
     ) -> Value {
         use crate::mir::equality::eval_equality;
 
-        let mut iter = arg_list_value.list_iter();
+        let mut iter = arg_list_value.unsized_list_iter();
 
         let left_value = iter.next_unchecked(b, span);
         let right_value = iter.next_unchecked(b, span);

--- a/compiler/mir/intrinsic/list.rs
+++ b/compiler/mir/intrinsic/list.rs
@@ -15,7 +15,7 @@ pub fn length(
     span: Span,
     arg_list_value: &Value,
 ) -> Result<Option<Value>> {
-    let mut iter = arg_list_value.list_iter();
+    let mut iter = arg_list_value.unsized_list_iter();
     let single_arg = iter.next_unchecked(b, span);
 
     if let Some(known_length) = list_value_length(&single_arg) {
@@ -53,7 +53,7 @@ pub fn cons(
     span: Span,
     arg_list_value: &Value,
 ) -> Result<Option<Value>> {
-    let mut iter = arg_list_value.list_iter();
+    let mut iter = arg_list_value.unsized_list_iter();
 
     let head = iter.next_unchecked(b, span);
     let rest = iter.next_unchecked(b, span);

--- a/compiler/mir/intrinsic/math.rs
+++ b/compiler/mir/intrinsic/math.rs
@@ -1,33 +1,308 @@
 use syntax::span::Span;
 
-use crate::mir::builder::Builder;
+use runtime::abitype;
+use runtime::boxed;
+
+use crate::mir::builder::{Builder, BuiltReg};
 use crate::mir::error::Result;
 use crate::mir::eval_hir::EvalHirCtx;
-use crate::mir::value::list::list_value_length;
-use crate::mir::Value;
+use crate::mir::ops::{BinaryOp, OpKind, RegId};
 
-pub fn add(
-    _ehx: &mut EvalHirCtx,
-    b: &mut Builder,
-    span: Span,
-    arg_list_value: &Value,
-) -> Result<Option<Value>> {
-    if list_value_length(&arg_list_value) == Some(1) {
-        Ok(Some(arg_list_value.list_iter().next_unchecked(b, span)))
-    } else {
-        Ok(None)
+use crate::mir::value;
+use crate::mir::value::build_reg::value_to_reg;
+use crate::mir::value::list::SizedListIterator;
+use crate::mir::value::Value;
+
+/// Represents a numerical operand of a known type
+enum NumOperand {
+    Int(BuiltReg),
+    Float(BuiltReg),
+}
+
+impl NumOperand {
+    /// Attempts to build numerical operand from a value
+    ///
+    /// If the value isn't a definite `Int` or `Float` this will return `None`
+    fn try_from_value(
+        ehx: &mut EvalHirCtx,
+        b: &mut Builder,
+        span: Span,
+        value: Value,
+    ) -> Option<NumOperand> {
+        use crate::mir::value::types::possible_type_tags_for_value;
+
+        let possible_type_tags = possible_type_tags_for_value(&value);
+
+        if possible_type_tags == boxed::TypeTag::Int.into() {
+            let int64_reg = value_to_reg(ehx, b, span, &value, &abitype::ABIType::Int);
+            Some(NumOperand::Int(int64_reg))
+        } else if possible_type_tags == boxed::TypeTag::Float.into() {
+            let float_reg = value_to_reg(ehx, b, span, &value, &abitype::ABIType::Float);
+            Some(NumOperand::Float(float_reg))
+        } else {
+            None
+        }
+    }
+
+    /// Converts this operand in to a value
+    fn into_value(self) -> Value {
+        match self {
+            NumOperand::Int(built_reg) => {
+                value::RegValue::new(built_reg, abitype::ABIType::Int).into()
+            }
+            NumOperand::Float(built_reg) => {
+                value::RegValue::new(built_reg, abitype::ABIType::Float).into()
+            }
+        }
     }
 }
 
-pub fn mul(
-    _ehx: &mut EvalHirCtx,
+/// Folds a series of numerical operands with the given reducers for `Int` and `Float`s
+fn fold_operands<I, F>(
+    ehx: &mut EvalHirCtx,
+    b: &mut Builder,
+    span: Span,
+    mut acc: NumOperand,
+    mut list_iter: SizedListIterator,
+    int64_op: I,
+    float_op: F,
+) -> Option<Value>
+where
+    I: Fn(RegId, BinaryOp) -> OpKind + Copy,
+    F: Fn(RegId, BinaryOp) -> OpKind + Copy,
+{
+    while let Some(value) = list_iter.next(b, span) {
+        let operand = NumOperand::try_from_value(ehx, b, span, value)?;
+
+        acc = match (acc, operand) {
+            (NumOperand::Int(lhs_reg), NumOperand::Int(rhs_reg)) => {
+                let result_reg = b.push_reg(
+                    span,
+                    int64_op,
+                    BinaryOp {
+                        lhs_reg: lhs_reg.into(),
+                        rhs_reg: rhs_reg.into(),
+                    },
+                );
+
+                NumOperand::Int(result_reg)
+            }
+            (NumOperand::Float(lhs_reg), NumOperand::Float(rhs_reg)) => {
+                let result_reg = b.push_reg(
+                    span,
+                    float_op,
+                    BinaryOp {
+                        lhs_reg: lhs_reg.into(),
+                        rhs_reg: rhs_reg.into(),
+                    },
+                );
+
+                NumOperand::Float(result_reg)
+            }
+            (NumOperand::Float(float_reg), NumOperand::Int(int_reg)) => {
+                let int_as_float_reg = b.push_reg(span, OpKind::Int64ToFloat, int_reg.into());
+
+                let result_reg = b.push_reg(
+                    span,
+                    float_op,
+                    BinaryOp {
+                        lhs_reg: float_reg.into(),
+                        rhs_reg: int_as_float_reg.into(),
+                    },
+                );
+
+                NumOperand::Float(result_reg)
+            }
+            (NumOperand::Int(int_reg), NumOperand::Float(float_reg)) => {
+                let int_as_float_reg = b.push_reg(span, OpKind::Int64ToFloat, int_reg.into());
+
+                let result_reg = b.push_reg(
+                    span,
+                    float_op,
+                    BinaryOp {
+                        lhs_reg: int_as_float_reg.into(),
+                        rhs_reg: float_reg.into(),
+                    },
+                );
+
+                NumOperand::Float(result_reg)
+            }
+        }
+    }
+
+    Some(acc.into_value())
+}
+
+/// Reduces a series of numerical operands with the given reducer ops for `Int` and `Float`s
+///
+/// This does not assume the reducers are associative
+fn reduce_operands<I, F>(
+    ehx: &mut EvalHirCtx,
+    b: &mut Builder,
+    span: Span,
+    mut list_iter: SizedListIterator,
+    int64_op: I,
+    float_op: F,
+) -> Option<Value>
+where
+    I: Fn(RegId, BinaryOp) -> OpKind + Copy,
+    F: Fn(RegId, BinaryOp) -> OpKind + Copy,
+{
+    let initial_value = list_iter.next(b, span).unwrap();
+    let acc = NumOperand::try_from_value(ehx, b, span, initial_value)?;
+
+    fold_operands(ehx, b, span, acc, list_iter, int64_op, float_op)
+}
+
+/// Reduces a series of numerical operands with the given reducer ops for `Int` and `Float`s
+///
+/// This assumes the reducers are associative
+fn reduce_assoc_operands<I, F>(
+    ehx: &mut EvalHirCtx,
+    b: &mut Builder,
+    span: Span,
+    arg_list_value: &Value,
+    int64_op: I,
+    float_op: F,
+) -> Option<Value>
+where
+    I: Fn(RegId, BinaryOp) -> OpKind + Copy,
+    F: Fn(RegId, BinaryOp) -> OpKind + Copy,
+{
+    let mut list_iter = arg_list_value.try_sized_list_iter()?;
+
+    if list_iter.len() == 1 {
+        // The associative math functions (`+` and `*`) act as the identity function with 1 arg.
+        // We check here so even if the value doesn't have a definite type it's still returned.
+        return list_iter.next(b, span);
+    }
+
+    reduce_operands(ehx, b, span, list_iter, int64_op, float_op)
+}
+
+pub fn add(
+    ehx: &mut EvalHirCtx,
     b: &mut Builder,
     span: Span,
     arg_list_value: &Value,
 ) -> Result<Option<Value>> {
-    if list_value_length(&arg_list_value) == Some(1) {
-        Ok(Some(arg_list_value.list_iter().next_unchecked(b, span)))
+    use crate::mir::ops::*;
+
+    Ok(reduce_assoc_operands(
+        ehx,
+        b,
+        span,
+        arg_list_value,
+        OpKind::Int64CheckedAdd,
+        OpKind::FloatAdd,
+    ))
+}
+
+pub fn mul(
+    ehx: &mut EvalHirCtx,
+    b: &mut Builder,
+    span: Span,
+    arg_list_value: &Value,
+) -> Result<Option<Value>> {
+    use crate::mir::ops::*;
+
+    Ok(reduce_assoc_operands(
+        ehx,
+        b,
+        span,
+        arg_list_value,
+        OpKind::Int64CheckedMul,
+        OpKind::FloatMul,
+    ))
+}
+
+pub fn sub(
+    ehx: &mut EvalHirCtx,
+    b: &mut Builder,
+    span: Span,
+    arg_list_value: &Value,
+) -> Result<Option<Value>> {
+    use crate::mir::ops::*;
+
+    let list_iter = if let Some(list_iter) = arg_list_value.try_sized_list_iter() {
+        list_iter
     } else {
-        Ok(None)
+        return Ok(None);
+    };
+
+    if list_iter.len() == 1 {
+        // Rewrite `(- x)` to `(- 0 x)`
+        let const_int_zero = NumOperand::Int(b.push_reg(span, OpKind::ConstInt64, 0));
+
+        Ok(fold_operands(
+            ehx,
+            b,
+            span,
+            const_int_zero,
+            list_iter,
+            OpKind::Int64CheckedSub,
+            OpKind::FloatSub,
+        ))
+    } else {
+        Ok(reduce_operands(
+            ehx,
+            b,
+            span,
+            list_iter,
+            OpKind::Int64CheckedSub,
+            OpKind::FloatSub,
+        ))
     }
+}
+
+pub fn div(
+    ehx: &mut EvalHirCtx,
+    b: &mut Builder,
+    span: Span,
+    arg_list_value: &Value,
+) -> Result<Option<Value>> {
+    use crate::mir::ops::*;
+
+    let mut list_iter = if let Some(list_iter) = arg_list_value.try_sized_list_iter() {
+        list_iter
+    } else {
+        return Ok(None);
+    };
+
+    let initial_value = list_iter.next(b, span).unwrap();
+    let initial_reg = value_to_reg(ehx, b, span, &initial_value, &abitype::ABIType::Float);
+
+    let result_reg = if list_iter.len() == 0 {
+        // Rewrite `(/ x)` to `(/ 1 x)`
+        let const_one_reg = b.push_reg(span, OpKind::ConstFloat, 1.0f64);
+
+        b.push_reg(
+            span,
+            OpKind::FloatDiv,
+            BinaryOp {
+                lhs_reg: const_one_reg.into(),
+                rhs_reg: initial_reg.into(),
+            },
+        )
+    } else {
+        let mut acc = initial_reg;
+        while let Some(value) = list_iter.next(b, span) {
+            let value_reg = value_to_reg(ehx, b, span, &value, &abitype::ABIType::Float);
+
+            acc = b.push_reg(
+                span,
+                OpKind::FloatDiv,
+                BinaryOp {
+                    lhs_reg: acc.into(),
+                    rhs_reg: value_reg.into(),
+                },
+            );
+        }
+
+        acc
+    };
+
+    Ok(Some(
+        value::RegValue::new(result_reg, abitype::ABIType::Float).into(),
+    ))
 }

--- a/compiler/mir/intrinsic/mod.rs
+++ b/compiler/mir/intrinsic/mod.rs
@@ -61,6 +61,8 @@ define_eval_intrinsics! {
 define_build_intrinsics! {
     "+" => math::add,
     "*" => math::mul,
+    "-" => math::sub,
+    "/" => math::div,
     "int" => number::int,
     "float" => number::float
 }

--- a/compiler/mir/intrinsic/number.rs
+++ b/compiler/mir/intrinsic/number.rs
@@ -14,7 +14,7 @@ pub fn int(
     span: Span,
     arg_list_value: &Value,
 ) -> Result<Option<Value>> {
-    let value = arg_list_value.list_iter().next_unchecked(b, span);
+    let value = arg_list_value.unsized_list_iter().next_unchecked(b, span);
 
     Ok(
         if possible_type_tags_for_value(&value) == TypeTag::Int.into() {
@@ -31,7 +31,7 @@ pub fn float(
     span: Span,
     arg_list_value: &Value,
 ) -> Result<Option<Value>> {
-    let value = arg_list_value.list_iter().next_unchecked(b, span);
+    let value = arg_list_value.unsized_list_iter().next_unchecked(b, span);
     let possible_type_tags = possible_type_tags_for_value(&value);
 
     Ok(if possible_type_tags == TypeTag::Float.into() {

--- a/compiler/mir/intrinsic/testing.rs
+++ b/compiler/mir/intrinsic/testing.rs
@@ -98,7 +98,7 @@ pub fn fn_op_categories(
     span: Span,
     arg_list_value: &Value,
 ) -> Result<Option<Value>> {
-    let mut iter = arg_list_value.list_iter();
+    let mut iter = arg_list_value.unsized_list_iter();
     let single_arg = iter.next_unchecked(b, span);
 
     let arret_fun = if let Value::ArretFun(arret_fun) = single_arg {

--- a/compiler/mir/ops.rs
+++ b/compiler/mir/ops.rs
@@ -165,13 +165,21 @@ pub enum OpKind {
 
     MakeCallback(RegId, MakeCallbackOp),
 
-    Add(RegId, BinaryOp),
     IntEqual(RegId, BinaryOp),
     CharEqual(RegId, BinaryOp),
     FloatEqual(RegId, BinaryOp),
     BoxIdentical(RegId, BinaryOp),
     UsizeToInt64(RegId, RegId),
     Int64ToFloat(RegId, RegId),
+
+    FloatAdd(RegId, BinaryOp),
+    UsizeAdd(RegId, BinaryOp),
+    Int64CheckedAdd(RegId, BinaryOp),
+    FloatMul(RegId, BinaryOp),
+    Int64CheckedMul(RegId, BinaryOp),
+    FloatSub(RegId, BinaryOp),
+    Int64CheckedSub(RegId, BinaryOp),
+    FloatDiv(RegId, BinaryOp),
 
     Ret(RegId),
     RetVoid,
@@ -232,7 +240,14 @@ impl OpKind {
             | LoadBoxedFloatValue(reg_id, _)
             | LoadBoxedCharValue(reg_id, _)
             | LoadBoxedFunThunkClosure(reg_id, _)
-            | Add(reg_id, _) => Some(*reg_id),
+            | FloatAdd(reg_id, _)
+            | UsizeAdd(reg_id, _)
+            | Int64CheckedAdd(reg_id, _)
+            | FloatMul(reg_id, _)
+            | Int64CheckedMul(reg_id, _)
+            | FloatSub(reg_id, _)
+            | Int64CheckedSub(reg_id, _)
+            | FloatDiv(reg_id, _) => Some(*reg_id),
             IntEqual(reg_id, _)
             | FloatEqual(reg_id, _)
             | CharEqual(reg_id, _)
@@ -339,7 +354,14 @@ impl OpKind {
                     op.kind().add_input_regs(coll);
                 }
             }
-            Add(_, binary_op)
+            FloatAdd(_, binary_op)
+            | UsizeAdd(_, binary_op)
+            | Int64CheckedAdd(_, binary_op)
+            | FloatMul(_, binary_op)
+            | Int64CheckedMul(_, binary_op)
+            | FloatSub(_, binary_op)
+            | Int64CheckedSub(_, binary_op)
+            | FloatDiv(_, binary_op)
             | IntEqual(_, binary_op)
             | FloatEqual(_, binary_op)
             | CharEqual(_, binary_op)
@@ -418,7 +440,14 @@ impl OpKind {
             | LoadBoxedCharValue(_, _)
             | LoadBoxedFunThunkClosure(_, _) => OpCategory::MemLoad,
 
-            Add(_, _)
+            FloatAdd(_, _)
+            | UsizeAdd(_, _)
+            | Int64CheckedAdd(_, _)
+            | FloatSub(_, _)
+            | Int64CheckedSub(_, _)
+            | FloatMul(_, _)
+            | Int64CheckedMul(_, _)
+            | FloatDiv(_, _)
             | IntEqual(_, _)
             | FloatEqual(_, _)
             | CharEqual(_, _)

--- a/compiler/mir/value/build_reg.rs
+++ b/compiler/mir/value/build_reg.rs
@@ -190,7 +190,7 @@ fn list_to_reg(
                         let index_reg = b.push_reg(span, OpKind::ConstUsize, i + 1);
                         b.push_reg(
                             span,
-                            OpKind::Add,
+                            OpKind::UsizeAdd,
                             BinaryOp {
                                 lhs_reg: rest_length_reg.into(),
                                 rhs_reg: index_reg.into(),

--- a/compiler/mir/value/mod.rs
+++ b/compiler/mir/value/mod.rs
@@ -74,12 +74,16 @@ pub enum Value {
 }
 
 impl Value {
-    pub fn list_iter(&self) -> list::ListIterator {
-        self.clone().into_list_iter()
+    pub fn unsized_list_iter(&self) -> list::UnsizedListIterator {
+        self.clone().into_unsized_list_iter()
     }
 
-    pub fn into_list_iter(self) -> list::ListIterator {
-        list::ListIterator::new(self)
+    pub fn into_unsized_list_iter(self) -> list::UnsizedListIterator {
+        list::UnsizedListIterator::new(self)
+    }
+
+    pub fn try_sized_list_iter(&self) -> Option<list::SizedListIterator> {
+        list::SizedListIterator::try_new(self)
     }
 }
 

--- a/compiler/tests/optimise/math.arret
+++ b/compiler/tests/optimise/math.arret
@@ -6,4 +6,47 @@
   (assert-fn-doesnt-contain-op :call (fn ([n Num])
     (+ (* n))))
 
+  ;
+  ; These should all be converted to MIR ops
+  ;
+
+  (assert-fn-doesnt-contain-op :call (fn ([left Int] [right Int])
+    (+ left right)))
+
+  (assert-fn-doesnt-contain-op :call (fn ([left Int] [right Float])
+    (+ left right)))
+
+  (assert-fn-doesnt-contain-op :call (fn ([left Float] [right Float])
+    (+ left right)))
+
+  (assert-fn-doesnt-contain-op :call (fn ([left Int] [right Int])
+    (* left right)))
+
+  (assert-fn-doesnt-contain-op :call (fn ([left Int] [right Float])
+    (* left right)))
+
+  (assert-fn-doesnt-contain-op :call (fn ([left Float] [right Float])
+    (* left right)))
+
+  (assert-fn-doesnt-contain-op :call (fn ([value Int])
+    (- value)))
+
+  (assert-fn-doesnt-contain-op :call (fn ([value Float])
+    (- value)))
+
+  (assert-fn-doesnt-contain-op :call (fn ([left Int] [right Int])
+    (- left right)))
+
+  (assert-fn-doesnt-contain-op :call (fn ([left Int] [right Float])
+    (- left right)))
+
+  (assert-fn-doesnt-contain-op :call (fn ([left Float] [right Float])
+    (- left right)))
+
+  (assert-fn-doesnt-contain-op :call (fn ([value Float])
+    (/ value)))
+
+  (assert-fn-doesnt-contain-op :call (fn ([left Float] [right Float])
+    (/ left right)))
+
   ())

--- a/compiler/tests/run-pass/math.arret
+++ b/compiler/tests/run-pass/math.arret
@@ -1,0 +1,40 @@
+(import [stdlib base])
+(import [stdlib test])
+
+(defn test-add ()
+  (assert-eq 4 (+ (black-box! 4)))
+
+  (assert-eq 7 (+ 4 (black-box! 3)))
+  (assert-eq 7.0 (+ (black-box! 4.0) 3))
+
+  ())
+
+(defn test-mul ()
+  (assert-eq 4 (* (black-box! 4)))
+
+  (assert-eq 12 (* (black-box! 4) 3))
+  (assert-eq 12.0 (* 4.0 (black-box! 3)))
+
+  ())
+
+(defn test-sub ()
+  (assert-eq -3.0 (- (black-box! 3.0)))
+  (assert-eq 3 (- (black-box! -3)))
+
+  (assert-eq 4 (- (black-box! 7) 3))
+  (assert-eq 4.0 (- 7 (black-box! 3.0)))
+
+  ())
+
+(defn test-div ()
+  (assert-eq 0.5 (/ (black-box! 2.0)))
+  (assert-eq 0.25 (/ 1.0 (black-box! 2.0) 2.0)))
+
+
+(defn main! () ->! ()
+  (test-add)
+  (test-mul)
+  (test-sub)
+  (test-div)
+
+  ())


### PR DESCRIPTION
This generates MIR ops for `+`, `-`, `*` and `/` when all operands have
a definite type. The integer ops include "Checked" in their name but
this is entirely aspirational at the moment.

This also adds a `SizedListIterator` which provides more traditional
iterator interface around lists of a known size. This is needed for our
math intrinsics and presumably other intrinsics with variable arity in
the future.