### PR TITLE
Math intrinsics for known Float results

### DIFF
--- a/compiler/tests/optimise/math.arret
+++ b/compiler/tests/optimise/math.arret
@@ -19,6 +19,9 @@
   (assert-fn-doesnt-contain-op :call (fn ([left Float] [right Float])
     (+ left right)))
 
+  (assert-fn-doesnt-contain-op :call (fn ([left Float] [right Num])
+    (+ left right)))
+
   (assert-fn-doesnt-contain-op :call (fn ([left Int] [right Int])
     (* left right)))
 
@@ -26,6 +29,9 @@
     (* left right)))
 
   (assert-fn-doesnt-contain-op :call (fn ([left Float] [right Float])
+    (* left right)))
+
+  (assert-fn-doesnt-contain-op :call (fn ([left Float] [right Num])
     (* left right)))
 
   (assert-fn-doesnt-contain-op :call (fn ([value Int])
@@ -41,6 +47,9 @@
     (- left right)))
 
   (assert-fn-doesnt-contain-op :call (fn ([left Float] [right Float])
+    (- left right)))
+
+  (assert-fn-doesnt-contain-op :call (fn ([left Float] [right Num])
     (- left right)))
 
   (assert-fn-doesnt-contain-op :call (fn ([value Float])


### PR DESCRIPTION
Currently we abort building intrinsics if we encounter a `Num` in any of
our operands. This is safe but we can do better.

This strives to match the behaviour of the stdlib in term of operation
and conversion order.  For multi-operand math operations we behave as if
we reduce our input pairwise from left to right. If either pairwise
operand is a `Float` then both operands are converted to `Float` and the
result is a `Float`.

The input-dependent result type makes it difficult for us to build
operations on values that aren't definite `Int` or `Float` (i.e. `Num`).
Once we encounter a known `Float` we can safely convert every remaining
operand to `Float` with at most a single branch per operand. However, if
we encounter an unknown `Num` along with another `Num` or `Int` we don't
know the result type of the pairwise operation. This can produce a
combinatorial explosion of branches.

For this reason this code will return `None` if it encounters a `Num`
before a `Float`. This will cause us to fallback to the stdlib at
runtime.