### PR TITLE
Arret implementation of (nan?) and (infinite?)

### DIFF
--- a/compiler/tests/eval-pass/number.arret
+++ b/compiler/tests/eval-pass/number.arret
@@ -17,6 +17,13 @@
   (assert-eq false (nan? ##Inf))
   (assert-eq false (nan? ##-Inf)))
 
+
+(defn test-infinite? ()
+  (assert-eq false (infinite? 3.0))
+  (assert-eq true (infinite? ##Inf))
+  (assert-eq true (infinite? ##-Inf))
+  (assert-eq false (infinite? ##NaN)))
+
 (defn test-float ()
   (assert-eq 1.0 (float 1))
   (assert-eq 0.0 (float 0))
@@ -39,6 +46,7 @@
 (defn main! () ->! ()
   (test-zero?)
   (test-nan?)
+  (test-infinite?)
   (test-float)
   (test-int)
   ())

--- a/stdlib/arret/base.arret
+++ b/stdlib/arret/base.arret
@@ -6,7 +6,7 @@
         sym? bool? num? int? float? char? list? vector? set? map? fn? nil?)
 
 (import [stdlib rust])
-(export length panic print! println! exit! cons map filter concat member? nan? int float + * - /)
+(export length panic print! println! exit! cons map filter concat member? int float + * - /)
 
 (export defn)
 (defmacro defn (macro-rules
@@ -72,6 +72,14 @@
   (if (int? n)
     (= n 0)
     (= n 0.0)))
+
+(export nan?)
+(defn nan? ([f Float])
+  (not (= f f)))
+
+(export infinite?)
+(defn infinite? ([f Float])
+  (or (= f ##Inf) (= f ##-Inf)))
 
 (export ->>)
 (defmacro ->> (macro-rules

--- a/stdlib/rust/lib.rs
+++ b/stdlib/rust/lib.rs
@@ -60,7 +60,6 @@ define_rust_module!(ARRET_STDLIB_RUST_EXPORTS, {
     "concat" => stdlib_concat,
     "member?" => stdlib_member_p,
 
-    "nan?" => stdlib_nan_p,
     "float" => stdlib_float,
     "int" => stdlib_int,
 

--- a/stdlib/rust/number.rs
+++ b/stdlib/rust/number.rs
@@ -5,11 +5,6 @@ use runtime::task::Task;
 
 use rfi_derive;
 
-#[rfi_derive::rust_fun("(Float -> Bool)")]
-pub fn stdlib_nan_p(float: f64) -> bool {
-    float.is_nan()
-}
-
 #[rfi_derive::rust_fun("(Num -> Float)")]
 pub fn stdlib_float(input: Gc<boxed::Num>) -> f64 {
     match input.as_subtype() {


### PR DESCRIPTION
`(nan?)` previously had a Rust implementation while `(infinite?)` was
unimplemented. There was no need to implement these is Rust; it's less
complex and easier to optimise as Arret.