### PR TITLE
Reuse conversion logic for (float)

### DIFF
--- a/compiler/mir/intrinsic/math.rs
+++ b/compiler/mir/intrinsic/math.rs
@@ -27,6 +27,7 @@ use crate::mir::builder::{Builder, BuiltReg};
 use crate::mir::error::Result;
 use crate::mir::eval_hir::EvalHirCtx;
 use crate::mir::ops::{BinaryOp, OpKind, RegId};
+use crate::mir::intrinsic::number::num_value_to_float_reg;
 
 use crate::mir::value;
 use crate::mir::value::build_reg::value_to_reg;
@@ -61,83 +62,6 @@ impl NumOperand {
         } else {
             None
         }
-    }
-}
-
-/// Converts a value of type `Num` to a float reg
-fn num_value_to_float_reg(
-    ehx: &mut EvalHirCtx,
-    outer_b: &mut Builder,
-    span: Span,
-    value: &Value,
-) -> BuiltReg {
-    use crate::mir::ops::*;
-
-    let num_type_tags = [boxed::TypeTag::Int, boxed::TypeTag::Float]
-        .iter()
-        .collect();
-
-    let possible_type_tags = possible_type_tags_for_value(value) & num_type_tags;
-
-    if possible_type_tags == boxed::TypeTag::Float.into() {
-        value_to_reg(ehx, outer_b, span, &value, &abitype::ABIType::Float)
-    } else if possible_type_tags == boxed::TypeTag::Int.into() {
-        let int64_reg = value_to_reg(ehx, outer_b, span, value, &abitype::ABIType::Int);
-        outer_b.push_reg(span, OpKind::Int64ToFloat, int64_reg.into())
-    } else {
-        let boxed_any_reg = value_to_reg(
-            ehx,
-            outer_b,
-            span,
-            value,
-            &abitype::BoxedABIType::Any.into(),
-        )
-        .into();
-
-        let value_type_tag_reg = outer_b.push_reg(
-            span,
-            OpKind::LoadBoxedTypeTag,
-            LoadBoxedTypeTagOp {
-                subject_reg: boxed_any_reg,
-                possible_type_tags: num_type_tags,
-            },
-        );
-
-        let float_tag_reg = outer_b.push_reg(span, OpKind::ConstTypeTag, boxed::TypeTag::Float);
-
-        let is_float_reg = outer_b.push_reg(
-            span,
-            OpKind::IntEqual,
-            BinaryOp {
-                lhs_reg: value_type_tag_reg.into(),
-                rhs_reg: float_tag_reg.into(),
-            },
-        );
-
-        let mut is_float_b = Builder::new();
-        let is_float_result_reg =
-            value_to_reg(ehx, &mut is_float_b, span, &value, &abitype::ABIType::Float);
-
-        let mut is_int_b = Builder::new();
-        let int64_reg = value_to_reg(ehx, &mut is_int_b, span, value, &abitype::ABIType::Int);
-        let is_int_result_reg = is_int_b.push_reg(span, OpKind::Int64ToFloat, int64_reg.into());
-
-        let output_reg = RegId::alloc();
-        outer_b.push(
-            span,
-            OpKind::Cond(CondOp {
-                reg_phi: Some(RegPhi {
-                    output_reg,
-                    true_result_reg: is_float_result_reg.into(),
-                    false_result_reg: is_int_result_reg.into(),
-                }),
-                test_reg: is_float_reg.into(),
-                true_ops: is_float_b.into_ops(),
-                false_ops: is_int_b.into_ops(),
-            }),
-        );
-
-        BuiltReg::Local(output_reg)
     }
 }
 

--- a/compiler/mir/intrinsic/number.rs
+++ b/compiler/mir/intrinsic/number.rs
@@ -1,12 +1,93 @@
 use syntax::span::Span;
 
-use runtime::boxed::TypeTag;
+use runtime::abitype;
+use runtime::boxed;
 
-use crate::mir::builder::Builder;
+use crate::mir::builder::{Builder, BuiltReg};
 use crate::mir::error::Result;
 use crate::mir::eval_hir::EvalHirCtx;
+
+use crate::mir::value;
+use crate::mir::value::build_reg::value_to_reg;
 use crate::mir::value::types::possible_type_tags_for_value;
-use crate::mir::Value;
+use crate::mir::value::Value;
+
+/// Converts a value of type `Num` to a float reg
+pub fn num_value_to_float_reg(
+    ehx: &mut EvalHirCtx,
+    outer_b: &mut Builder,
+    span: Span,
+    value: &Value,
+) -> BuiltReg {
+    use crate::mir::ops::*;
+
+    let num_type_tags = [boxed::TypeTag::Int, boxed::TypeTag::Float]
+        .iter()
+        .collect();
+
+    let possible_type_tags = possible_type_tags_for_value(value) & num_type_tags;
+
+    if possible_type_tags == boxed::TypeTag::Float.into() {
+        value_to_reg(ehx, outer_b, span, &value, &abitype::ABIType::Float)
+    } else if possible_type_tags == boxed::TypeTag::Int.into() {
+        let int64_reg = value_to_reg(ehx, outer_b, span, value, &abitype::ABIType::Int);
+        outer_b.push_reg(span, OpKind::Int64ToFloat, int64_reg.into())
+    } else {
+        let boxed_any_reg = value_to_reg(
+            ehx,
+            outer_b,
+            span,
+            value,
+            &abitype::BoxedABIType::Any.into(),
+        )
+        .into();
+
+        let value_type_tag_reg = outer_b.push_reg(
+            span,
+            OpKind::LoadBoxedTypeTag,
+            LoadBoxedTypeTagOp {
+                subject_reg: boxed_any_reg,
+                possible_type_tags: num_type_tags,
+            },
+        );
+
+        let float_tag_reg = outer_b.push_reg(span, OpKind::ConstTypeTag, boxed::TypeTag::Float);
+
+        let is_float_reg = outer_b.push_reg(
+            span,
+            OpKind::IntEqual,
+            BinaryOp {
+                lhs_reg: value_type_tag_reg.into(),
+                rhs_reg: float_tag_reg.into(),
+            },
+        );
+
+        let mut is_float_b = Builder::new();
+        let is_float_result_reg =
+            value_to_reg(ehx, &mut is_float_b, span, &value, &abitype::ABIType::Float);
+
+        let mut is_int_b = Builder::new();
+        let int64_reg = value_to_reg(ehx, &mut is_int_b, span, value, &abitype::ABIType::Int);
+        let is_int_result_reg = is_int_b.push_reg(span, OpKind::Int64ToFloat, int64_reg.into());
+
+        let output_reg = RegId::alloc();
+        outer_b.push(
+            span,
+            OpKind::Cond(CondOp {
+                reg_phi: Some(RegPhi {
+                    output_reg,
+                    true_result_reg: is_float_result_reg.into(),
+                    false_result_reg: is_int_result_reg.into(),
+                }),
+                test_reg: is_float_reg.into(),
+                true_ops: is_float_b.into_ops(),
+                false_ops: is_int_b.into_ops(),
+            }),
+        );
+
+        BuiltReg::Local(output_reg)
+    }
+}
 
 pub fn int(
     _ehx: &mut EvalHirCtx,
@@ -17,7 +98,7 @@ pub fn int(
     let value = arg_list_value.unsized_list_iter().next_unchecked(b, span);
 
     Ok(
-        if possible_type_tags_for_value(&value) == TypeTag::Int.into() {
+        if possible_type_tags_for_value(&value) == boxed::TypeTag::Int.into() {
             Some(value)
         } else {
             None
@@ -32,21 +113,12 @@ pub fn float(
     arg_list_value: &Value,
 ) -> Result<Option<Value>> {
     let value = arg_list_value.unsized_list_iter().next_unchecked(b, span);
-    let possible_type_tags = possible_type_tags_for_value(&value);
 
-    Ok(if possible_type_tags == TypeTag::Float.into() {
-        Some(value)
-    } else if possible_type_tags == TypeTag::Int.into() {
-        use crate::mir::ops::*;
-        use crate::mir::value;
-        use crate::mir::value::build_reg::value_to_reg;
-        use runtime::abitype;
-
-        let int_reg = value_to_reg(ehx, b, span, &value, &abitype::ABIType::Int);
-        let float_reg = b.push_reg(span, OpKind::Int64ToFloat, int_reg.into());
-
-        Some(value::RegValue::new(float_reg, abitype::ABIType::Float).into())
-    } else {
-        None
-    })
+    Ok(Some(
+        value::RegValue::new(
+            num_value_to_float_reg(ehx, b, span, &value),
+            abitype::ABIType::Float,
+        )
+        .into(),
+    ))
 }

--- a/compiler/tests/optimise/number.arret
+++ b/compiler/tests/optimise/number.arret
@@ -10,8 +10,10 @@
   (assert-fn-doesnt-contain-op :call (fn ([f Float])
     (float f)))
 
-  ; We can build specific MIR ops for this
+  ; We can build specific MIR ops for these
   (assert-fn-doesnt-contain-op :call (fn ([i Int])
     (float i)))
+  (assert-fn-doesnt-contain-op :call (fn ([n Num])
+    (float n)))
 
   ())


### PR DESCRIPTION
We gained some pretty serious code for converting `Value`s to float regs
as part of our math support. Move this to `number.rs` and reuse it for
our `(float)` implementation so it can work on values of unknown types.