### PR TITLE
Basic support for GCC cross compile

### DIFF
--- a/.buildkite/cross-i686.sh
+++ b/.buildkite/cross-i686.sh
@@ -5,7 +5,7 @@ set -e
 TARGET_TRIPLE=i686-unknown-linux-gnu
 . ./driver/tests/integration/config.sh
 
-apt-get -y install gcc-multilib
+apt-get -y install gcc-multilib file
 
 rustup target add $TARGET_TRIPLE
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,8 @@ FROM ubuntu:18.04 AS build-env
 
 RUN \
   apt-get update && \
-  apt-get -y install curl clang-7 zlib1g-dev llvm-7 llvm-7-dev && \
+  apt-get -y install curl gcc zlib1g-dev libstdc++-7-dev llvm-7 llvm-7-dev && \
   apt-get clean
-
-# Use Clang as it understands LLVM target triples
-RUN update-alternatives --install /usr/bin/cc cc /usr/bin/clang-7 100
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.33.0
 ENV PATH "/root/.cargo/bin:${PATH}"

--- a/compiler/codegen/program.rs
+++ b/compiler/codegen/program.rs
@@ -163,6 +163,17 @@ fn program_to_module(
     }
 }
 
+fn target_triple_to_cc_args(target_triple: &str) -> Vec<&str> {
+    // Try to use -m32 when possible for compatibility with GCC
+    if (cfg!(target_arch = "x86_64") && target_triple.starts_with("i686-"))
+        || (cfg!(target_arch = "aarch64") && target_triple.starts_with("arm"))
+    {
+        vec!["-m32"]
+    } else {
+        vec!["-target", target_triple]
+    }
+}
+
 /// Generates code for the program with the given output type
 ///
 /// codegen::initialise_llvm() must be called before this.
@@ -241,7 +252,7 @@ pub fn gen_program(
 
     if output_type == OutputType::Executable {
         let target_args = match target_triple {
-            Some(triple) => vec!["-target", triple],
+            Some(triple) => target_triple_to_cc_args(triple),
             None => vec![],
         };
 


### PR DESCRIPTION
Right now we use `cc -target` when cross compiling. This implicitly assumes we're using Clang. For a couple of obvious cases pass `-m32` instead which both GCC and Clang understand.