### PR TITLE
Move cross compile to LLVM assert step

### DIFF
--- a/.buildkite/cross-i686.sh
+++ b/.buildkite/cross-i686.sh
@@ -5,10 +5,6 @@ set -e
 TARGET_TRIPLE=i686-unknown-linux-gnu
 . ./driver/tests/integration/config.sh
 
-apt-get -y install gcc-multilib file
-
-rustup target add $TARGET_TRIPLE
-
 # Cross-compile just stdlib
 cargo build --target $TARGET_TRIPLE -p stdlib
 

--- a/.buildkite/llvm-assert.Dockerfile
+++ b/.buildkite/llvm-assert.Dockerfile
@@ -4,7 +4,7 @@ ARG LLVM_MAJOR=7
 ARG LLVM_VERSION=7.0.1
 ARG LLVM_ROOT=/opt/llvm-${LLVM_MAJOR}
 
-RUN dnf install -y curl cmake ninja-build gcc-c++ xz && \
+RUN dnf install -y file cmake ninja-build gcc-c++ glibc-devel.i686 xz && \
   dnf clean all
 
 WORKDIR /usr/src
@@ -26,4 +26,6 @@ RUN ninja install && rm -Rf /usr/src/llvm-build
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.33.0
 
 ENV PATH "/root/.cargo/bin:${PATH}"
+RUN rustup target add i686-unknown-linux-gnu
+
 ENV LLVM_SYS_70_PREFIX "${LLVM_ROOT}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,12 +7,11 @@ cached-ecr-build-env: &cached-ecr-build-env
     - docker#v2.0.0
 
 steps:
-  - label: ":ubuntu: Test x86-64 & i686"
+  - label: ":ubuntu: Test x86-64"
     command:
       - cargo check --release
       - cargo build
       - cargo test
-      - ./.buildkite/cross-i686.sh
       - ./driver/tests/integration/run.sh target/debug/arret
     <<: *cached-ecr-build-env
 
@@ -27,11 +26,12 @@ steps:
     agents:
       queue: arm64
 
-  - label: ":fedora: Test with LLVM Assertions"
+  - label: ":fedora: Test LLVM Assert & i686"
     branches: '!master'
     command:
       - cargo build
       - cargo test
+      - ./.buildkite/cross-i686.sh
       - ./driver/tests/integration/run.sh target/debug/arret
     plugins:
       - seek-oss/docker-ecr-cache#v1.1.1:


### PR DESCRIPTION
This has a few motivations:

- It'd be nice to run the i686 build with assertions to make sure we're
  not making any 64bit assumptions that asserts will catch.

- The test x86-64 step takes ~5m while the LLVM assert step takes ~3m.
  This can hopefully even out the time a bit.

- The LLVM assert step has a distinct Dockerfile from the main build so
  we can pre-cache our cross compile tools instead of downloading them
  every time.