### PR TITLE
Add (inc) and (dec)

### DIFF
--- a/compiler/tests/eval-pass/math.arret
+++ b/compiler/tests/eval-pass/math.arret
@@ -53,10 +53,24 @@
 
   ())
 
+(defn test-inc-dec ()
+  (assert-eq -1 (inc -2))
+  (assert-eq 0 (inc -1))
+  (assert-eq 1 (inc 0))
+  (assert-eq 2 (inc 1))
+
+  (assert-eq -2 (dec -1))
+  (assert-eq -1 (dec 0))
+  (assert-eq 0 (dec 1))
+  (assert-eq 1 (dec 2))
+
+  ())
+
 (defn main! () ->! ()
   (test-add)
   (test-mul)
   (test-sub)
   (test-div)
+  (test-inc-dec)
 
   ())

--- a/stdlib/arret/base.arret
+++ b/stdlib/arret/base.arret
@@ -74,12 +74,20 @@
     (= n 0.0)))
 
 (export nan?)
-(defn nan? ([f Float])
+(defn nan? ([f Float]) -> Bool
   (not (= f f)))
 
 (export infinite?)
-(defn infinite? ([f Float])
+(defn infinite? ([f Float]) -> Bool
   (or (= f ##Inf) (= f ##-Inf)))
+
+(export inc)
+(defn inc ([i Int]) -> Int
+  (+ i 1))
+
+(export dec)
+(defn dec ([i Int]) -> Int
+  (- i 1))
 
 (export ->>)
 (defmacro ->> (macro-rules


### PR DESCRIPTION
Unlike Clojure these only support integers. Floats have strange
behaviour on inc/dec at the extremes of their range and this should
allow better type inference.