### PR TITLE
Represent fixed lists with never rests

### DIFF
--- a/compiler/hir/destruc.rs
+++ b/compiler/hir/destruc.rs
@@ -113,8 +113,8 @@ pub fn poly_for_list_destruc(list: &List<hir::Inferred>) -> ty::List<ty::Poly> {
     let fixed_polys = list.fixed().iter().map(poly_for_destruc).collect();
 
     let rest_poly = match list.rest() {
-        Some(rest) => Some(rest.ty().clone()),
-        None => None,
+        Some(rest) => rest.ty().clone(),
+        None => ty::Ty::never().into(),
     };
 
     ty::List::new(fixed_polys, rest_poly)

--- a/compiler/hir/rfi/mod.rs
+++ b/compiler/hir/rfi/mod.rs
@@ -73,7 +73,7 @@ impl Fun {
     }
 
     pub fn has_rest(&self) -> bool {
-        self.arret_fun_type.params().rest().is_some()
+        !self.arret_fun_type.params().rest().is_never()
     }
 
     pub fn ret(&self) -> &'static abitype::RetABIType {
@@ -196,7 +196,7 @@ impl Loader {
 
         // Calculate how many parameters the Rust function should accept
         let expected_rust_params = upper_fun_type.params().fixed().len()
-            + upper_fun_type.params().rest().is_some() as usize;
+            + !upper_fun_type.params().rest().is_never() as usize;
 
         if expected_rust_params != rust_fun.params.len() {
             return Err(Error::new(
@@ -215,7 +215,8 @@ impl Loader {
         let mut abi_params_iter = rust_fun.params.iter();
 
         // If there are rest types ensure they're compatible
-        if let Some(arret_rest) = upper_fun_type.params().rest() {
+        let arret_rest = upper_fun_type.params().rest();
+        if !arret_rest.is_never() {
             use runtime::abitype::{ABIType, BoxedABIType};
 
             let last_rust_param = abi_params_iter.next_back().unwrap();

--- a/compiler/mir/intrinsic/testing.rs
+++ b/compiler/mir/intrinsic/testing.rs
@@ -38,10 +38,9 @@ fn ideal_polymorph_abi_for_arret_fun(arret_fun: &value::ArretFun) -> PolymorphAB
             specific_abi_type_for_ty_ref(&fixed_poly)
         }))
         .chain(
-            param_list_type
-                .rest()
-                .into_iter()
-                .map(|_| abitype::TOP_LIST_BOXED_ABI_TYPE.into()),
+            Some(abitype::TOP_LIST_BOXED_ABI_TYPE.into())
+                .filter(|_| !param_list_type.rest().is_never())
+                .into_iter(),
         )
         .collect();
 
@@ -55,7 +54,7 @@ fn ideal_polymorph_abi_for_arret_fun(arret_fun: &value::ArretFun) -> PolymorphAB
     PolymorphABI {
         ops_abi,
         has_closure,
-        has_rest: param_list_type.rest().is_some(),
+        has_rest: !param_list_type.rest().is_never(),
     }
 }
 

--- a/compiler/mir/value/types.rs
+++ b/compiler/mir/value/types.rs
@@ -15,7 +15,7 @@ pub fn mono_to_const(
     match mono.as_ty() {
         ty::Ty::LitBool(value) => Some(boxed::Bool::singleton_ref(*value).as_any_ref()),
         ty::Ty::LitSym(value) => Some(boxed::Sym::new(heap, value.as_ref()).as_any_ref()),
-        ty::Ty::List(list) if list.rest().is_none() => {
+        ty::Ty::List(list) if list.rest().is_never() => {
             let fixed_consts = list
                 .fixed()
                 .iter()

--- a/compiler/tests/eval-pass/list.arret
+++ b/compiler/tests/eval-pass/list.arret
@@ -10,15 +10,14 @@
 (defn test-first-rest ()
   (assert-eq 'one (ann (first '(one two three)) 'one))
   (assert-eq '(two three) (ann (rest '(one two three)) (Listof Sym)))
-  ; TODO: The type of this is `(Listof Any)`. Can this be more specific?
-  (assert-eq () (rest '(one))))
+  (assert-eq () (ann (rest '(one)) '())))
 
 (defn test-cons ()
-  (assert-eq '(1) (cons 1 '()))
+  (assert-eq '(1) (ann (cons 1 '()) (List Int)))
   (assert-eq '((1 2) 3) (cons '(1 2) '(3))))
 
 (defn test-map ()
-  (assert-eq '() (map (fn (x) x) '()))
+  (assert-eq '() (ann (map (fn (x) x) '()) '()))
   (assert-eq '(1 2 3 4 5) (map (fn (x) x) '(1 2 3 4 5)))
   (assert-eq '(0 1 2 3) (map #(length %) '(() (1) (1 2) (1 2 3))))
   (assert-eq '(4 4 4) (map (fn (x) 4) '(1 2 3)))

--- a/compiler/ty/conv_abi.rs
+++ b/compiler/ty/conv_abi.rs
@@ -19,7 +19,7 @@ fn type_tag_to_ty<M: ty::PM>(type_tag: boxed::TypeTag) -> ty::Ty<M> {
         TypeTag::TopVector => ty::Ty::Vectorof(Box::new(ty::Ty::Any.into())),
         TypeTag::Nil => ty::List::empty().into(),
         TypeTag::TopPair => {
-            ty::List::new(Box::new([ty::Ty::Any.into()]), Some(ty::Ty::Any.into())).into()
+            ty::List::new(Box::new([ty::Ty::Any.into()]), ty::Ty::Any.into()).into()
         }
         TypeTag::FunThunk => ty::TopFun::new(Purity::Impure.into(), ty::Ty::Any.into()).into(),
     }
@@ -65,12 +65,10 @@ impl ConvertableABIType for abitype::BoxedABIType {
         match self {
             BoxedABIType::Any => ty::Ty::Any.into(),
             BoxedABIType::Vector(member) => ty::Ty::Vectorof(Box::new(member.to_ty_ref())).into(),
-            BoxedABIType::List(member) => {
-                ty::List::new(Box::new([]), Some(member.to_ty_ref())).into()
-            }
+            BoxedABIType::List(member) => ty::List::new(Box::new([]), member.to_ty_ref()).into(),
             BoxedABIType::Pair(member) => {
                 let member_ty_ref: ty::Ref<M> = member.to_ty_ref();
-                ty::List::new(Box::new([member_ty_ref.clone()]), Some(member_ty_ref)).into()
+                ty::List::new(Box::new([member_ty_ref.clone()]), member_ty_ref).into()
             }
             BoxedABIType::DirectTagged(type_tag) => type_tag_to_ty(*type_tag).into(),
             BoxedABIType::Union(_, tags) => {
@@ -128,7 +126,7 @@ impl ConvertableABIType for callback::EntryPointABIType {
             .map(|abi_type| abi_type.to_ty_ref())
             .collect();
 
-        let param_list_ty = ty::List::new(fixed_param_ty_refs, None);
+        let param_list_ty = ty::List::new(fixed_param_ty_refs, ty::Ty::never().into());
 
         ty::Fun::new(
             purity::PVarIds::new(),
@@ -173,7 +171,7 @@ mod test {
         assert_eq!("boxed::TopList", boxed_abi_type.to_rust_str());
 
         let top_list_poly: ty::Ref<ty::Poly> =
-            ty::List::new(Box::new([]), Some(ty::Ty::Any.into())).into();
+            ty::List::new(Box::new([]), ty::Ty::Any.into()).into();
 
         assert_eq!(top_list_poly, boxed_abi_type.to_ty_ref());
     }
@@ -188,7 +186,7 @@ mod test {
         assert_eq!("boxed::Pair<boxed::Int>", boxed_abi_type.to_rust_str());
 
         let int_pair_poly: ty::Ref<ty::Poly> =
-            ty::List::new(Box::new([ty::Ty::Int.into()]), Some(ty::Ty::Int.into())).into();
+            ty::List::new(Box::new([ty::Ty::Int.into()]), ty::Ty::Int.into()).into();
 
         assert_eq!(int_pair_poly, boxed_abi_type.to_ty_ref());
     }
@@ -234,7 +232,7 @@ mod test {
             purity::PVarIds::new(),
             ty::TVarIds::new(),
             ty::TopFun::new(Purity::Impure.into(), ty::Ty::Char.into()),
-            ty::List::new(Box::new([ty::Ty::Int.into()]), None),
+            ty::List::new(Box::new([ty::Ty::Int.into()]), ty::Ty::never().into()),
         )
         .into();
 

--- a/compiler/ty/datum.rs
+++ b/compiler/ty/datum.rs
@@ -11,7 +11,7 @@ pub fn ty_ref_for_datum<M: ty::PM>(datum: &Datum) -> ty::Ref<M> {
         Datum::Str(_, _) => ty::Ty::Str,
         Datum::List(_, vs) => ty::List::new(
             vs.iter().map(|datum| ty_ref_for_datum(datum)).collect(),
-            None,
+            ty::Ty::never().into(),
         )
         .into(),
         Datum::Vector(_, vs) => ty::Ty::Vector(vs.iter().map(|v| ty_ref_for_datum(v)).collect()),

--- a/compiler/ty/intersect.rs
+++ b/compiler/ty/intersect.rs
@@ -247,11 +247,7 @@ pub fn intersect_list<M: ty::PM>(list1: &ty::List<M>, list2: &ty::List<M>) -> Re
         merged_fixed.push(merged_next);
     }
 
-    let merged_rest = match (list1.rest(), list2.rest()) {
-        (Some(rest1), Some(rest2)) => Some(intersect_ty_refs(rest1, rest2)?),
-        _ => None,
-    };
-
+    let merged_rest = intersect_ty_refs(list1.rest(), list2.rest())?;
     Ok(ty::List::new(merged_fixed.into_boxed_slice(), merged_rest))
 }
 

--- a/compiler/ty/is_a.rs
+++ b/compiler/ty/is_a.rs
@@ -9,28 +9,18 @@ fn top_fun_is_a(sub_top_fun: &ty::TopFun, par_top_fun: &ty::TopFun) -> bool {
 }
 
 fn list_is_a<M: ty::PM>(sub_list: &ty::List<M>, par_list: &ty::List<M>) -> bool {
-    if (sub_list.fixed().len() > par_list.fixed().len()) && par_list.rest().is_none() {
+    if (sub_list.fixed().len() > par_list.fixed().len()) && par_list.rest().is_never() {
         // sub is longer than par
         return false;
     }
 
     if sub_list.fixed().len() < par_list.fixed().len() {
-        // sub is less specific due to less fixed typew
+        // sub is less specific due to less fixed types
         return false;
     }
 
-    if let Some(sub_rest) = sub_list.rest() {
-        match par_list.rest() {
-            Some(par_rest) => {
-                if !ty_ref_is_a(sub_rest, par_rest) {
-                    return false;
-                }
-            }
-            None => {
-                // Rest makes sub less specific
-                return false;
-            }
-        }
+    if !ty_ref_is_a(sub_list.rest(), par_list.rest()) {
+        return false;
     }
 
     // Compare our fixed types. If the par fixed ends early we'll use the par rest.

--- a/compiler/ty/mod.rs
+++ b/compiler/ty/mod.rs
@@ -227,37 +227,34 @@ impl<M: PM> From<Map<M>> for Ref<M> {
 #[derive(PartialEq, Eq, Debug, Hash, Clone)]
 pub struct List<M: PM> {
     fixed: Box<[Ref<M>]>,
-    rest: Option<Box<Ref<M>>>,
+    rest: Box<Ref<M>>,
 }
 
 impl<M: PM> List<M> {
-    pub fn new(fixed: Box<[Ref<M>]>, rest: Option<Ref<M>>) -> List<M> {
+    pub fn new(fixed: Box<[Ref<M>]>, rest: Ref<M>) -> List<M> {
         List {
             fixed,
-            rest: rest.map(Box::new),
+            rest: Box::new(rest),
         }
     }
 
     pub fn empty() -> List<M> {
-        List::new(Box::new([]), None)
+        List::new(Box::new([]), Ty::never().into())
     }
 
     pub fn fixed(&self) -> &[Ref<M>] {
         &self.fixed
     }
 
-    pub fn rest(&self) -> Option<&Ref<M>> {
-        match self.rest {
-            Some(ref rest) => Some(rest.as_ref()),
-            None => None,
-        }
+    pub fn rest(&self) -> &Ref<M> {
+        self.rest.as_ref()
     }
 
     fn size_range(&self) -> Range<usize> {
-        if self.rest.is_some() {
-            (self.fixed.len()..usize::max_value())
-        } else {
+        if self.rest.is_never() {
             (self.fixed.len()..self.fixed.len())
+        } else {
+            (self.fixed.len()..usize::max_value())
         }
     }
 
@@ -269,7 +266,7 @@ impl<M: PM> List<M> {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.fixed.is_empty() && self.rest.is_none()
+        self.fixed.is_empty() && self.rest.is_never()
     }
 }
 
@@ -365,7 +362,7 @@ impl Fun {
             purity::PVarIds::new(),
             TVarIds::new(),
             TopFun::new_for_pred(),
-            List::new(Box::new([Ty::Any.into()]), None),
+            List::new(Box::new([Ty::Any.into()]), Ty::never().into()),
         )
     }
 
@@ -378,7 +375,10 @@ impl Fun {
             purity::PVarIds::new(),
             TVarIds::new(),
             TopFun::new_for_pred(),
-            List::new(Box::new([Ty::Any.into(), Ty::Any.into()]), None),
+            List::new(
+                Box::new([Ty::Any.into(), Ty::Any.into()]),
+                Ty::never().into(),
+            ),
         )
     }
 

--- a/compiler/ty/pred.rs
+++ b/compiler/ty/pred.rs
@@ -95,7 +95,7 @@ impl TestTy {
             TestTy::Int => ty::Ty::Int,
             TestTy::Float => ty::Ty::Float,
             TestTy::Char => ty::Ty::Char,
-            TestTy::List => ty::List::new(Box::new([]), Some(ty::Ty::Any.into())).into(),
+            TestTy::List => ty::List::new(Box::new([]), ty::Ty::Any.into()).into(),
             TestTy::Vector => ty::Ty::Vectorof(Box::new(ty::Ty::Any.into())),
             TestTy::Set => ty::Ty::Set(Box::new(ty::Ty::Any.into())),
             TestTy::Map => ty::Map::new(ty::Ty::Any.into(), ty::Ty::Any.into()).into(),
@@ -229,7 +229,7 @@ mod test {
     #[test]
     fn list_test_ty() {
         assert_trivial_test_ty(
-            ty::List::new(Box::new([]), Some(ty::Ty::Any.into())).into(),
+            ty::List::new(Box::new([]), ty::Ty::Any.into()).into(),
             TestTy::List,
         );
     }
@@ -270,11 +270,11 @@ mod test {
         let test_ty = TestTy::Nil;
 
         assert_test_ty_will_match(test_ty, ty::List::empty());
-        assert_test_ty_may_match(
+        assert_test_ty_may_match(test_ty, ty::List::new(Box::new([]), ty::Ty::Any.into()));
+        assert_test_ty_wont_match(
             test_ty,
-            ty::List::new(Box::new([]), Some(ty::Ty::Any.into())),
+            ty::List::new(Box::new([ty::Ty::Any.into()]), ty::Ty::never().into()),
         );
-        assert_test_ty_wont_match(test_ty, ty::List::new(Box::new([ty::Ty::Any.into()]), None));
     }
 
     #[test]
@@ -287,7 +287,7 @@ mod test {
         assert_test_ty_wont_match(TestTy::Int, str_sym_union.clone());
 
         let list_false_union: ty::Ref<ty::Poly> = ty::Ty::Union(Box::new([
-            ty::List::new(Box::new([]), Some(ty::Ty::Any.into())).into(),
+            ty::List::new(Box::new([]), ty::Ty::Any.into()).into(),
             ty::Ty::LitBool(false).into(),
         ]))
         .into();

--- a/compiler/ty/props.rs
+++ b/compiler/ty/props.rs
@@ -15,7 +15,7 @@ fn ty_has_subtypes<M: ty::PM>(ty: &ty::Ty<M>) -> bool {
         ty::Ty::Fun(fun) => {
             fun.purity() != &Purity::Pure.into()
                 || !fun.params().fixed().is_empty()
-                || fun.params().rest() != Some(&ty::Ty::Any.into())
+                || fun.params().rest() != &ty::Ty::Any.into()
                 || has_subtypes(fun.ret())
         }
         ty::Ty::Map(map) => has_subtypes(map.key()) || has_subtypes(map.value()),
@@ -24,7 +24,7 @@ fn ty_has_subtypes<M: ty::PM>(ty: &ty::Ty<M>) -> bool {
         ty::Ty::Union(members) => !members.is_empty(),
         ty::Ty::List(list) => {
             // Any arbitrary fixed length list is a subtype of a list with rest
-            list.rest().is_some() || list.fixed().iter().any(has_subtypes)
+            !list.rest().is_never() || list.fixed().iter().any(has_subtypes)
         }
         ty::Ty::Vectorof(_) => {
             // Any arbitrary fixed length vector is a subtype of this vector
@@ -48,7 +48,7 @@ fn ty_is_literal<M: ty::PM>(ty: &ty::Ty<M>) -> bool {
     match ty {
         ty::Ty::LitBool(_) | ty::Ty::LitSym(_) => true,
         ty::Ty::Vector(members) => members.iter().all(is_literal),
-        ty::Ty::List(list) => list.rest().is_none() && list.fixed().iter().all(is_literal),
+        ty::Ty::List(list) => list.rest().is_never() && list.fixed().iter().all(is_literal),
         _ => false,
     }
 }

--- a/compiler/ty/select.rs
+++ b/compiler/ty/select.rs
@@ -75,9 +75,7 @@ impl<'vars> SelectCtx<'vars> {
         }
 
         if let Some(target_rest) = target_iter.next() {
-            if let Some(evidence_rest) = evidence_iter.collect_rest() {
-                self.add_evidence(target_rest, &evidence_rest);
-            }
+            self.add_evidence(target_rest, &evidence_iter.collect_rest());
         }
     }
 

--- a/compiler/ty/subst.rs
+++ b/compiler/ty/subst.rs
@@ -15,7 +15,7 @@ where
 {
     ty::List::new(
         subst_ty_ref_slice(stx, list.fixed()),
-        list.rest().map(|r| stx.subst_ty_ref(r)),
+        stx.subst_ty_ref(list.rest()),
     )
 }
 

--- a/compiler/ty/subtract.rs
+++ b/compiler/ty/subtract.rs
@@ -36,19 +36,20 @@ fn subtract_tys<M: ty::PM>(
         (ty::Ty::List(minuend_list), ty::Ty::List(subtrahend_list))
             // Make sure this is even useful or else we can recurse splitting list types
             // indefinitely
-            if subtrahend_list.rest().is_none() && minuend_list.fixed().len() == subtrahend_list.fixed().len() =>
+            if subtrahend_list.rest().is_never() && minuend_list.fixed().len() == subtrahend_list.fixed().len() =>
         {
             // This is required for `(nil?)` to work correctly
-            if let Some(rest) = minuend_list.rest() {
+            let minued_rest = minuend_list.rest();
+            if !minued_rest.is_never() {
                 // This is the list type if we have no rest elements
                 let terminated_list =
-                    ty::List::new(minuend_list.fixed().to_vec().into_boxed_slice(), None);
+                    ty::List::new(minuend_list.fixed().to_vec().into_boxed_slice(), ty::Ty::never().into());
 
                 // This is the list type if we have at least one rest element
                 let mut continued_fixed = minuend_list.fixed().to_vec();
-                continued_fixed.push(rest.clone());
+                continued_fixed.push(minued_rest.clone());
                 let continued_list =
-                    ty::List::new(continued_fixed.into_boxed_slice(), Some(rest.clone()));
+                    ty::List::new(continued_fixed.into_boxed_slice(), minued_rest.clone());
 
                 subtract_ref_iters(
                     [

--- a/compiler/typeck/destruc.rs
+++ b/compiler/typeck/destruc.rs
@@ -20,13 +20,13 @@ pub fn type_for_decl_list_destruc(
     }
 
     let rest_poly = match list.rest() {
-        Some(rest) => Some(match rest.ty() {
+        Some(rest) => match rest.ty() {
             hir::DeclTy::Known(poly) => poly.clone(),
             hir::DeclTy::Free => guide_type_iter
-                .and_then(|guide_type_iter| guide_type_iter.collect_rest())
+                .map(|guide_type_iter| guide_type_iter.collect_rest())
                 .unwrap_or_else(|| ty::Ty::Any.into()),
-        }),
-        None => None,
+        },
+        None => ty::Ty::never().into(),
     };
 
     ty::List::new(fixed_polys.into_boxed_slice(), rest_poly)


### PR DESCRIPTION
As an experiment I attempted to raise an error whenever our type inference couldn't select on a type or purity var. This was to both make our type system more strict and catch corner cases in our select code. However, this ran in to a number of errors like the following:

```
error: cannot determine type of type variable `T` in this context
  --> ./tests/eval-pass/list.arret:17:19
   |
17 |   (assert-eq '(1) (cons 1 '()))
   |                   ^^^^^^^^^^^^
```

This was a previously known (and mostly forgotten) issue where an empty list can't be used as type evidence against another list. In this case the result type becomes `(Listof Int Any ...)` because it defaults to `T` being `Any`.

It may be possible to hack this in to `select.rs` and `subst.rs` without changing our list representation. However, this also makes `is_a`, `unify` and `infer` simpler as they can use normal type system logic on rest types without special casing if the rest is present or not.