### PR TITLE
Use lack of rest arg as evidence

### DIFF
--- a/compiler/tests/eval-pass/list.arret
+++ b/compiler/tests/eval-pass/list.arret
@@ -43,7 +43,7 @@
   (assert-eq 5.0 (fold + -1.0 '(1.0 2.0 3.0))))
 
 (defn test-concat ()
-  (assert-eq '() (concat))
+  (assert-eq '() (ann (concat) '()))
   (assert-eq '(1 2 3) (concat '(1 2 3)))
   (assert-eq '(1 2 3 4 5 6) (concat '(1 2 3) '() '(4 5 6))))
 

--- a/compiler/typeck/infer.rs
+++ b/compiler/typeck/infer.rs
@@ -860,6 +860,8 @@ impl<'types> RecursiveDefsCtx<'types> {
                 ErrorKind::WrongArity(supplied_arg_count, wanted_arity),
             ));
         } else {
+            // We can use the lack of a rest arg as type evidence
+            fun_param_stx.add_evidence(&param_iter.collect_rest(), &ty::Ty::never().into());
             None
         };
 


### PR DESCRIPTION
During an experiment to require all poly vars to be selected during type inference I encountered this error:

```
error: cannot determine type of type variable `T` in this context
  --> ./tests/eval-pass/list.arret:47:18
   |
47 |   (assert-eq '() (concat))
   |                  ^^^^^^^^
```

On `master` this instead infers the type of `Any` for `T` which while correct isn't well constrained.

We can fix this with two changes:

1. During type inference we can use an empty list as evidence for the rest type even if there wasn't a rest expression at the apply.

2. Whenever a never type is used as evidence type we should propagate the never type in to any collections. This is needed because `(concat)` takes a list of lists.