### PR TITLE
Support rest args in polymorph type selection

### DIFF
--- a/compiler/hir/rfi/mod.rs
+++ b/compiler/hir/rfi/mod.rs
@@ -190,7 +190,7 @@ impl Loader {
         let pvar_ids = poly_fun_type.pvar_ids();
         let tvar_ids = poly_fun_type.tvar_ids();
 
-        // The Rust function signature should match the upper bound of the Arret type
+        // The Rust function signature should satisfy the upper bound of the Arret type
         let pta = ty::ty_args::TyArgs::from_upper_bound(pvar_ids, tvar_ids);
         let upper_fun_type = ty::subst::subst_poly_fun(&pta, &*poly_fun_type);
 

--- a/compiler/mir/eval_hir.rs
+++ b/compiler/mir/eval_hir.rs
@@ -1077,20 +1077,9 @@ impl EvalHirCtx {
         // Try to refine our polymorphic type variables based on our requested op ABI
         let mut stx = ty::select::SelectCtx::new(&fun_expr.pvar_ids, &fun_expr.tvar_ids);
 
-        // TODO: Our rest param's ABI type should be a list ABI type but this isn't guaranteed by
-        // our `OpsABI` representation. This makes including the rest param difficult.
-        for (fixed_destruc, wanted_param_abi) in fun_expr
-            .params
-            .fixed()
-            .iter()
-            .zip(wanted_abi.arret_fixed_params())
-        {
-            use crate::ty::conv_abi::ConvertableABIType;
-            stx.add_evidence(
-                &hir::destruc::poly_for_destruc(fixed_destruc),
-                &wanted_param_abi.to_ty_ref(),
-            );
-        }
+        let fun_param_poly = hir::destruc::poly_for_list_destruc(&fun_expr.params);
+        let wanted_abi_poly = wanted_abi.param_ty_ref();
+        stx.add_evidence(&fun_param_poly.into(), &wanted_abi_poly.into());
 
         let ty_args = stx.into_poly_ty_args();
 


### PR DESCRIPTION
When building a polymorph of an Arret fun we try to "seed" the polymorphic types with the ABI of the polymorph. This is to support more precise monomorphisation of the Arret fun - for example, we can generate better code if we know a value is an `Int` instead of just a `Num`.

The existing code didn't want to deal with rest args so it did some gross zipping thing. Instead make a proper method on `PolymorphABI` and use the full param list type. This allows us to collect type information from our rest arg.

This depends on the rest arg always being in a `BoxedABIType::List`. This currently holds true and we'll panic if that changes.