### PR TITLE
Store span inside PVar and TVar

### DIFF
--- a/compiler/ty/mod.rs
+++ b/compiler/ty/mod.rs
@@ -16,10 +16,13 @@ use std::fmt;
 use std::hash;
 use std::ops::Range;
 
+use syntax::span::Span;
+
 use crate::id_type::RcId;
 
 #[derive(PartialEq, Eq, Debug, Hash, Clone)]
 pub struct TVar {
+    span: Span,
     source_name: Box<str>,
     bound: Ref<Poly>,
 }
@@ -28,8 +31,12 @@ pub type TVarId = RcId<TVar>;
 pub type TVarIds = Vec<TVarId>;
 
 impl TVar {
-    pub fn new(source_name: Box<str>, bound: Ref<Poly>) -> TVar {
-        TVar { source_name, bound }
+    pub fn new(span: Span, source_name: Box<str>, bound: Ref<Poly>) -> TVar {
+        TVar { span, source_name, bound }
+    }
+
+    pub fn span(&self) -> Span {
+        self.span
     }
 
     pub fn source_name(&self) -> &str {

--- a/compiler/ty/props.rs
+++ b/compiler/ty/props.rs
@@ -64,6 +64,7 @@ pub fn is_literal<M: ty::PM>(ty_ref: &ty::Ref<M>) -> bool {
 mod test {
     use super::*;
     use crate::hir::poly_for_str;
+    use syntax::span::EMPTY_SPAN;
 
     fn str_has_subtypes(datum_str: &str) -> bool {
         let poly = poly_for_str(datum_str);
@@ -107,7 +108,7 @@ mod test {
 
         assert_eq!(false, str_has_subtypes("(RawU)"));
 
-        let tvar_id = ty::TVarId::new(ty::TVar::new("test".into(), ty::Ty::Any.into()));
+        let tvar_id = ty::TVarId::new(ty::TVar::new(EMPTY_SPAN, "test".into(), ty::Ty::Any.into()));
         assert_eq!(true, has_subtypes(&ty::Ref::Var(tvar_id, ty::Poly {})));
     }
 
@@ -138,7 +139,7 @@ mod test {
         assert_eq!(false, str_is_literal("(Vectorof false)"));
         assert_eq!(true, str_is_literal("(Vector false true)"));
 
-        let tvar_id = ty::TVarId::new(ty::TVar::new("test".into(), ty::Ty::Any.into()));
+        let tvar_id = ty::TVarId::new(ty::TVar::new(EMPTY_SPAN, "test".into(), ty::Ty::Any.into()));
         assert_eq!(false, is_literal(&ty::Ref::Var(tvar_id, ty::Poly {})));
     }
 }

--- a/compiler/ty/purity.rs
+++ b/compiler/ty/purity.rs
@@ -1,3 +1,5 @@
+use syntax::span::Span;
+
 use crate::id_type::RcId;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
@@ -8,6 +10,7 @@ pub enum Purity {
 
 #[derive(PartialEq, Eq, Debug, Hash, Clone)]
 pub struct PVar {
+    span: Span,
     source_name: Box<str>,
 }
 
@@ -15,8 +18,12 @@ pub type PVarId = RcId<PVar>;
 pub type PVarIds = Vec<PVarId>;
 
 impl PVar {
-    pub fn new(source_name: Box<str>) -> PVar {
-        PVar { source_name }
+    pub fn new(span: Span, source_name: Box<str>) -> PVar {
+        PVar { span, source_name }
+    }
+
+    pub fn span(&self) -> Span {
+        self.span
     }
 
     pub fn source_name(&self) -> &str {

--- a/compiler/ty/unify.rs
+++ b/compiler/ty/unify.rs
@@ -37,7 +37,7 @@ pub enum UnifiedList<M: ty::PM> {
 
 fn unify_ty_refs<M: ty::PM>(ref1: &ty::Ref<M>, ref2: &ty::Ref<M>) -> UnifiedTy<M> {
     if let (ty::Ref::Fixed(ty1), ty::Ref::Fixed(ty2)) = (&ref1, &ref2) {
-        // We can invoke full simplfication logic if we have fixed types
+        // We can invoke full simplification logic if we have fixed types
         unify_ty(ref1, ty1, ref2, ty2)
     } else if ty::is_a::ty_ref_is_a(ref1, ref2) {
         UnifiedTy::Merged(ref2.clone())
@@ -341,7 +341,7 @@ mod test {
         let poly1 = poly_for_str(ty_str1);
         let poly2 = poly_for_str(ty_str2);
 
-        // This is the basic invariant we're testing - each of our input types satsifies the merged
+        // This is the basic invariant we're testing - each of our input types satisfies the merged
         // type
         assert_eq!(true, ty::is_a::ty_ref_is_a(&poly1, &expected));
         assert_eq!(true, ty::is_a::ty_ref_is_a(&poly2, &expected));
@@ -524,13 +524,15 @@ mod test {
 
     #[test]
     fn purity_refs() {
+        use syntax::span::EMPTY_SPAN;
+
         let purity_pure = Purity::Pure.into();
         let purity_impure = Purity::Impure.into();
 
-        let pvar_id1 = purity::PVarId::new(purity::PVar::new("test".into()));
+        let pvar_id1 = purity::PVarId::new(purity::PVar::new(EMPTY_SPAN, "test".into()));
         let purity_var1 = purity::Ref::Var(pvar_id1);
 
-        let pvar_id2 = purity::PVarId::new(purity::PVar::new("test".into()));
+        let pvar_id2 = purity::PVarId::new(purity::PVar::new(EMPTY_SPAN, "test".into()));
         let purity_var2 = purity::Ref::Var(pvar_id2);
 
         assert_eq!(purity_pure, unify_purity_refs(&purity_pure, &purity_pure));


### PR DESCRIPTION
Right now our error messages refer to pvars/tvars by their source name, e.g. `T`. However, when adding errors messages at the site of a function's usage these will typically be meaningless without also seeing its definition. This will allows us to span associated messages showing the original definition.