### PR TITLE
Error on unselected poly vars during inference

### DIFF
--- a/compiler/tests/compile-fail/type-checking-errors.arret
+++ b/compiler/tests/compile-fail/type-checking-errors.arret
@@ -86,4 +86,14 @@
                ;^^^^^ ERROR inferred conflicting types `B` and `A`
   ())
 
+(defn unselected-purity-variable ()
+  ((fn #{[->_ ->!]} ()))
+ ;^^^^^^^^^^^^^^^^^^^^^^ ERROR cannot determine purity of purity variable `->_` in this context
+  ())
+
+(defn unselected-type-variable ()
+  ((fn #{T} ()))
+ ;^^^^^^^^^^^^^^ ERROR cannot determine type of type variable `T` in this context
+  ())
+
 (defn main! ())


### PR DESCRIPTION
If we can't determine the value of a polymorphic variable while inferring a function application one of three things happened:

1. The function has a superfluous poly var

2. The function's type signature is incorrect (e.g. the poly var only appears in the return)

3. Our type system, particularly the selection code, has a bug in its implementation

This causes us to error out on unselected poly vars with a message like this:

```
arret> ((fn #{T} ()))
error: cannot determine type of type variable `T` in this context
  |
1 | ((fn #{T} ()))
  | ^^^^^^^^^^^^^^
help: type variable defined here
  |
1 | ((fn #{T} ()))
  |        ^
```

This leaves a hole open for type vars that have a bound. I'm unsure that this is a good idea but it's required for functions like this:

```
(All #{[N Num]} N ... -> N)
```

This is the type signature of `+` and `*` where we will return an `Int` if no arguments are passed. It might be cleaner to raise an error in this case and make `+` and `*` require at least one argument. That can be done as a separate change.