### PR TITLE
Run rustfmt --check as part of Buildkite pipeline

### DIFF
--- a/.buildkite/llvm-assert.Dockerfile
+++ b/.buildkite/llvm-assert.Dockerfile
@@ -27,6 +27,7 @@ RUN ninja install && rm -Rf /usr/src/llvm-build
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.33.0
 
 ENV PATH "/root/.cargo/bin:${PATH}"
+RUN rustup component add rustfmt
 RUN rustup target add i686-unknown-linux-gnu
 
 ENV LLVM_SYS_70_PREFIX "${LLVM_ROOT}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,6 +29,9 @@ steps:
     command:
       - ./.buildkite/build-and-test.sh
 
+      - "echo '--- :prettier: Checking rustfmt'"
+      - cargo fmt -- --check
+
       - "echo '--- :older_man: Testing i686 cross-compile'"
       - ./.buildkite/cross-i686.sh
     plugins:

--- a/compiler/ty/mod.rs
+++ b/compiler/ty/mod.rs
@@ -32,7 +32,11 @@ pub type TVarIds = Vec<TVarId>;
 
 impl TVar {
     pub fn new(span: Span, source_name: Box<str>, bound: Ref<Poly>) -> TVar {
-        TVar { span, source_name, bound }
+        TVar {
+            span,
+            source_name,
+            bound,
+        }
     }
 
     pub fn span(&self) -> Span {

--- a/runtime/boxed/refs.rs
+++ b/runtime/boxed/refs.rs
@@ -95,7 +95,9 @@ macro_rules! define_marker_ref {
 
         impl<T: Boxed> From<$ref_name<T>> for Gc<T> {
             fn from(marker_ref: $ref_name<T>) -> Gc<T> {
-                Gc { inner: marker_ref.inner }
+                Gc {
+                    inner: marker_ref.inner,
+                }
             }
         }
     };


### PR DESCRIPTION
This is placed in the LLVM assert pipeline for two reasons:

1. We build a custom Docker container for that pipeline so it's easy to add extra dependencies.

2. It's currently the shortest pipeline when the Docker container is up-to-date.