### PR TITLE
Significantly simplify macro system

### DIFF
--- a/compiler/hir/mod.rs
+++ b/compiler/hir/mod.rs
@@ -24,7 +24,7 @@ use crate::ty::purity;
 /// DeclTy is a type declared by a user
 ///
 /// The `Known` variant indicates the type is specified while `Free` indicates it must be inferred.
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum DeclTy {
     Known(ty::Ref<ty::Poly>),
     Free,

--- a/compiler/hir/scope.rs
+++ b/compiler/hir/scope.rs
@@ -11,7 +11,7 @@ use crate::hir::{types, VarId};
 use crate::ty;
 use crate::ty::purity;
 
-#[derive(Clone, PartialEq, Eq, Debug, Hash)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum Binding {
     Var(VarId),
     Prim(Prim),

--- a/compiler/tests/compile-fail/macro-errors.arret
+++ b/compiler/tests/compile-fail/macro-errors.arret
@@ -13,9 +13,6 @@
 (defmacro no-rules (macro-rules))
 (no-rules) ;~ ERROR no matching macro rule
 
-(defmacro _ (macro-rules #{a 1}))
-                            ;^ ERROR expected symbol
-
 (defmacro _ (macro-rules 1))
                         ;^ ERROR expected a macro rule vector
 
@@ -53,9 +50,9 @@
 (defmacro return-one (macro-rules [() 1]))
 (return-one extra-arg) ;~ ERROR no matching macro rule
 
-; Literal doesn't match
-(defmacro for (macro-rules #{in} [(x in y) [x y]]))
-(for 1 for 2) ;~ ERROR no matching macro rule
+; Keyword doesn't match
+(defmacro for (macro-rules [(x :in y) [x y]]))
+(for 1 :for 2) ;~ ERROR no matching macro rule
 
 (defmacro two-set? (macro-rules
   [(#{_ _}) false]

--- a/compiler/tests/eval-pass/macros.arret
+++ b/compiler/tests/eval-pass/macros.arret
@@ -15,15 +15,11 @@
   (letmacro [swap (macro-rules [(x y) '(y x)])]
     (assert-eq (swap one two) '(two one)))
 
-  (letmacro [for (macro-rules #{in} [(x in y) [x y]])]
-    (assert-eq (for two in one) [two one]))
+  (letmacro [for (macro-rules [(x :in y) [x y]])]
+    (assert-eq (for two :in one) [two one]))
 
   (letmacro [return-ellipsis (macro-rules [() '(... ...)])]
     (assert-eq (return-ellipsis) '...))
-
-  (letmacro [m (macro-rules #{_} [(_) 'underscore][(a) a])]
-    (assert-eq (m 'not-underscore) 'not-underscore)
-    (assert-eq (m _) 'underscore))
 
   (letmacro [list-third (macro-rules [(_ _ x) x])]
     (assert-eq (list-third 'one 'two 'three) 'three))

--- a/compiler/ty/mod.rs
+++ b/compiler/ty/mod.rs
@@ -13,14 +13,13 @@ pub mod ty_args;
 pub mod unify;
 
 use std::fmt;
-use std::hash;
 use std::ops::Range;
 
 use syntax::span::Span;
 
 use crate::id_type::RcId;
 
-#[derive(PartialEq, Eq, Debug, Hash, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct TVar {
     span: Span,
     source_name: Box<str>,
@@ -53,12 +52,12 @@ impl TVar {
 }
 
 /// Marker that determines if type variables are allowed within a type
-pub trait PM: PartialEq + Eq + Clone + Copy + Sized + fmt::Debug + hash::Hash {
+pub trait PM: PartialEq + Clone + Copy + Sized + fmt::Debug {
     /// Resolves a possibly variable type to its bound
     fn resolve_ref_to_ty(ty_ref: &Ref<Self>) -> &Ty<Self>;
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub enum Mono {}
 impl PM for Mono {
     fn resolve_ref_to_ty(ty_ref: &Ref<Mono>) -> &Ty<Mono> {
@@ -69,7 +68,7 @@ impl PM for Mono {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub struct Poly {}
 impl PM for Poly {
     fn resolve_ref_to_ty(ty_ref: &Ref<Poly>) -> &Ty<Poly> {
@@ -80,7 +79,7 @@ impl PM for Poly {
     }
 }
 
-#[derive(PartialEq, Eq, Debug, Hash, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum Ref<M: PM> {
     Var(TVarId, M),
     Fixed(Ty<M>),
@@ -160,7 +159,7 @@ impl<M: PM> From<Ty<M>> for Ref<M> {
     }
 }
 
-#[derive(PartialEq, Eq, Debug, Hash, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum Ty<M: PM> {
     Any,
     Bool,
@@ -203,7 +202,7 @@ impl<M: PM> Ty<M> {
     }
 }
 
-#[derive(PartialEq, Eq, Debug, Hash, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct Map<M: PM> {
     key: Ref<M>,
     value: Ref<M>,
@@ -235,7 +234,7 @@ impl<M: PM> From<Map<M>> for Ref<M> {
     }
 }
 
-#[derive(PartialEq, Eq, Debug, Hash, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct List<M: PM> {
     fixed: Box<[Ref<M>]>,
     rest: Box<Ref<M>>,
@@ -293,7 +292,7 @@ impl<M: PM> From<List<M>> for Ref<M> {
     }
 }
 
-#[derive(PartialEq, Eq, Debug, Hash, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct TopFun {
     purity: purity::Ref,
     ret: Ref<Poly>,
@@ -331,7 +330,7 @@ impl<M: PM> From<TopFun> for Ref<M> {
     }
 }
 
-#[derive(PartialEq, Eq, Debug, Hash, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct Fun {
     pvar_ids: purity::PVarIds,
     tvar_ids: TVarIds,


### PR DESCRIPTION
The current macro system is a slightly simplified form of the one in `etaoins/llambda`. By default symbols represent macro variables in the pattern and template. However, if the symbols are designated as macro literals they're instead matched during macro expansion. Bound literal
identifiers are matched based on their binding while unbound identifiers are matched on their name.

This ultimately comes from R7RS, particularly this text:

```
An element in the input matches a literal identifier if and only if it is an identifier and either both its occurrence in the macro expression and its occurrence in the macro definition have the same lexical binding, or the two identifiers are the same and both have no lexical binding.
```

While this very literal implementation of R7RS worked as expected, it had a number of disadvantages:

1. Simple bound values such as primitives and variables have trivial equality checks. However, as we add increasingly abstract and complex bound values this becomes harder to provide. For example, we attempt to match on bound types but `(U Int Float)` and `(U Float Int)` are two unequal types that are otherwise indistinguishable by the type system.

   We had to provide `Eq` and `Hash` implementations on types to support macros even though those operations had tenuous applicability in general. While it was a corner case to macro match on types the existence of the `Eq` and `Hash` implementations made it tempting to use them in more dangerous situations.

2. The macro code consistently shows up at the top of our profiling runs (after excluding LLVM). This is due to how macro-heavy our language is (e.g. almost everything is inside a `defn` macro) and that macro expansion must unconditionally happen over all code to determine its structure. The `MacroVar` abstraction made it difficult to control the number of scope lookups and allocations we performed.

Based on a quick survey of the macros defined in Clojure this system can be vastly simplified. Literal identifiers are rarely used in Clojure macro patterns, instead depending on parameter ordering or the richer data types available to Clojure. When identifiers are used they're nearly always keywords (e.g. `cond`'s use of `:else`).

This allows us to leverage the distinction between symbols and macros in Clojure. We can treat symbols always as variables while keywords can be treated always at literals. This removes the concept of macro-designated literals entirely.

As keywords cannot map to a bound value by definition this removes the `MacroVar` abstraction entirely in favour of `ns::Ident`. This is both less complex and should be significantly more performant.

This also remove the `Eq` and `Hash` impls for our type system value object now they're unused.

While this sounds like a big conceptual shift it actually did not affect any of our macros outside or our macro integration tests. That is further evidence that our complex system of literals wasn't well used and the keyword literals should hopefully meet our future requirements.

When running our integration tests inside Callgrind this resulted in 3.7% fewer memory allocations and 20% fewer instructions spent in `scope.rs`