### PR TITLE
Don't make wildcard a prim

### DIFF
--- a/compiler/hir/macros/checker.rs
+++ b/compiler/hir/macros/checker.rs
@@ -82,13 +82,12 @@ impl<'scope, 'data> FindVarsCtx<'scope, 'data> {
         span: Span,
         ident: &'data Ident,
     ) -> FindVarsResult {
-        let binding = self.scope.get(ident);
-
-        if binding == Some(&Binding::Prim(Prim::Wildcard)) {
+        if ident.name() == "_" {
             // This is a wildcard
             return Ok(());
         }
 
+        let binding = self.scope.get(ident);
         if binding == Some(&Binding::Prim(Prim::Ellipsis)) {
             return Err(Error::new(
                 span,

--- a/compiler/hir/macros/matcher.rs
+++ b/compiler/hir/macros/matcher.rs
@@ -2,8 +2,7 @@ use std::result;
 
 use crate::hir::macros::{starts_with_zero_or_more, MatchData, Rule};
 use crate::hir::ns::{Ident, NsDatum};
-use crate::hir::prim::Prim;
-use crate::hir::scope::{Binding, Scope};
+use crate::hir::scope::Scope;
 
 struct MatchCtx<'scope, 'data> {
     scope: &'scope Scope,
@@ -26,7 +25,7 @@ impl<'scope, 'data> MatchCtx<'scope, 'data> {
         pattern_ident: &'data Ident,
         arg: &'data NsDatum,
     ) -> MatchVisitResult {
-        if self.scope.get(pattern_ident) == Some(&Binding::Prim(Prim::Wildcard)) {
+        if pattern_ident.name() == "_" {
             // This is a wildcard; just discard
             Ok(())
         } else {

--- a/compiler/hir/prim.rs
+++ b/compiler/hir/prim.rs
@@ -31,7 +31,6 @@ export_prims!(
     ("defmacro", DefMacro),
     ("letmacro", LetMacro),
     ("...", Ellipsis),
-    ("_", Wildcard),
     ("macro-rules", MacroRules),
     ("deftype", DefType),
     ("lettype", LetType),

--- a/stdlib/arret/base.arret
+++ b/stdlib/arret/base.arret
@@ -1,5 +1,5 @@
 (import [arret internal primitives])
-(export def let fn if quote export ... _ defmacro letmacro macro-rules deftype compile-error do =)
+(export def let fn if quote export ... defmacro letmacro macro-rules deftype compile-error do =)
 
 (import [arret internal types])
 (export Any Bool Str Sym Int Float Num Char List Listof Vector Vectorof Setof Map U -> ->! str?


### PR DESCRIPTION
Instead of having a prim for `_` just check for its name literally. There's not much value in binding this to a different name and it could be confusing if it wasn't imported. This also lets us skip a bunch of potentially expensive scope lookups.