### PR TITLE
Use Clojure rest syntax

### DIFF
--- a/compiler/hir/lowering.rs
+++ b/compiler/hir/lowering.rs
@@ -216,7 +216,7 @@ fn lower_list_destruc(
     scope: &mut Scope,
     mut data_iter: NsDataIter,
 ) -> Result<destruc::List<Lowered>> {
-    let rest = try_take_rest_arg(scope, &mut data_iter);
+    let rest = try_take_rest_arg(&mut data_iter);
 
     let fixed_destrucs = data_iter
         .map(|v| lower_destruc(scope, v))
@@ -448,7 +448,7 @@ fn lower_expr_apply(
     fun_expr: Expr<Lowered>,
     mut arg_iter: NsDataIter,
 ) -> Result<Expr<Lowered>> {
-    let rest_arg_datum = try_take_rest_arg(scope, &mut arg_iter);
+    let rest_arg_datum = try_take_rest_arg(&mut arg_iter);
 
     let fixed_arg_exprs = arg_iter
         .map(|arg_datum| lower_expr(scope, arg_datum))
@@ -1132,11 +1132,11 @@ mod test {
 
     #[test]
     fn rest_expr_apply() {
-        let j = "(1 2 3 ...)";
-        let t = "^^^^^^^^^^^";
-        let u = " ^         ";
-        let v = "   ^       ";
-        let w = "     ^     ";
+        let j = "(1 2 & 3)";
+        let t = "^^^^^^^^^";
+        let u = " ^       ";
+        let v = "   ^     ";
+        let w = "       ^ ";
 
         let expected = Expr::new(
             t2s(t),

--- a/compiler/hir/rfi/mod.rs
+++ b/compiler/hir/rfi/mod.rs
@@ -32,10 +32,10 @@ impl Library {
 pub struct Fun {
     rust_library_id: RustLibraryId,
 
-    /// Name of this function if it corresponds to an instrinsic
+    /// Name of this function if it corresponds to an intrinsic
     ///
-    /// Intrinsics may have optimized partial evaluation in MIR. However, they should be
-    /// semantically equivalent to the non-instrinsic version.
+    /// Intrinsics may have optimised partial evaluation in MIR. However, they should be
+    /// semantically equivalent to the non-intrinsic version.
     intrinsic_name: Option<&'static str>,
 
     arret_fun_type: ty::Fun,
@@ -380,7 +380,7 @@ mod test {
     #[test]
     fn inexact_rust_fun_with_rest() {
         const BINDING_RUST_FUN: binding::RustFun = binding::RustFun {
-            arret_type: "(Int ... -> false)",
+            arret_type: "(& Int -> false)",
             takes_task: false,
             params: &[ParamABIType {
                 abi_type: ABIType::Boxed(BoxedABIType::List(&BoxedABIType::DirectTagged(
@@ -427,7 +427,7 @@ mod test {
     #[test]
     fn polymorphic_rust_fun() {
         const BINDING_RUST_FUN: binding::RustFun = binding::RustFun {
-            arret_type: "(All #{A} (List A Any ...) -> A)",
+            arret_type: "(All #{A} (List A & Any) -> A)",
             takes_task: false,
             params: &[ParamABIType {
                 abi_type: ABIType::Boxed(BoxedABIType::Pair(&BoxedABIType::Any)),
@@ -443,7 +443,7 @@ mod test {
     #[test]
     fn incompatible_polymorphic_rust_fun() {
         const BINDING_RUST_FUN: binding::RustFun = binding::RustFun {
-            arret_type: "(All #{A} (List Any ...) -> A)",
+            arret_type: "(All #{A} (List & Any) -> A)",
             takes_task: false,
             params: &[ParamABIType {
                 abi_type: ABIType::Boxed(BoxedABIType::Pair(&BoxedABIType::Any)),
@@ -454,7 +454,7 @@ mod test {
         };
 
         let kind = ErrorKind::RustFunError(
-            "Rust type `Gc<boxed::Pair<boxed::Any>>` does not match declared Arret type of `(Listof Any)`".into(),
+            "Rust type `Gc<boxed::Pair<boxed::Any>>` does not match declared Arret type of `(List & Any)`".into(),
         );
         assert_binding_fun_error(&kind, &BINDING_RUST_FUN);
     }
@@ -496,7 +496,7 @@ mod test {
     #[test]
     fn non_list_rust_rest_param() {
         const BINDING_RUST_FUN: binding::RustFun = binding::RustFun {
-            arret_type: "(Int ... -> true)",
+            arret_type: "(& Int -> true)",
             takes_task: false,
             params: &[ParamABIType {
                 abi_type: ABIType::Boxed(BoxedABIType::DirectTagged(TypeTag::Int)),

--- a/compiler/mir/polymorph.rs
+++ b/compiler/mir/polymorph.rs
@@ -9,7 +9,7 @@ use crate::ty;
 
 /// PolymorphABI annotates OpsABI with information about if a function expects a closure or rest
 ///
-/// This is information that's useful while generating MIR but can be discared when building Ops.
+/// This is information that's useful while generating MIR but can be discarded when building Ops.
 #[derive(PartialEq, Eq, Hash, Clone)]
 pub struct PolymorphABI {
     pub ops_abi: ops::OpsABI,
@@ -172,7 +172,7 @@ mod test {
         use runtime::boxed;
 
         let thunk_param_poly = PolymorphABI::thunk_abi().param_ty_ref();
-        let expected_poly = hir::poly_for_str("(Listof Any)");
+        let expected_poly = hir::poly_for_str("(List & Any)");
         assert_eq!(expected_poly, thunk_param_poly.into());
 
         let mul_param_poly = PolymorphABI {
@@ -188,7 +188,7 @@ mod test {
         }
         .param_ty_ref();
 
-        let expected_poly = hir::poly_for_str("(List Num Num ...)");
+        let expected_poly = hir::poly_for_str("(List Num & Num)");
         assert_eq!(expected_poly, mul_param_poly.into());
     }
 }

--- a/compiler/mir/specific_abi_type.rs
+++ b/compiler/mir/specific_abi_type.rs
@@ -113,7 +113,7 @@ mod test {
         assert_abi_type_for_str(abitype::ABIType::Int, "Int");
         assert_abi_type_for_str(boxed::Num::BOXED_ABI_TYPE.into(), "Num");
 
-        assert_abi_type_for_str(boxed::TopList::BOXED_ABI_TYPE.into(), "(Listof Any)");
+        assert_abi_type_for_str(boxed::TopList::BOXED_ABI_TYPE.into(), "(List & Any)");
 
         assert_abi_type_for_str(abitype::ABIType::Char, "Char");
 

--- a/compiler/reporting.rs
+++ b/compiler/reporting.rs
@@ -203,7 +203,7 @@ impl Reportable for syntax::error::Error {
             ErrorKind::UnexpectedChar(c) => format!("unexpected `{}`", c),
             ErrorKind::UnevenMap => "map literal must have an even number of values".to_owned(),
             ErrorKind::InvalidArgLiteral => {
-                "arg literal must be `%`, `%{integer}` or `%...`".to_owned()
+                "arg literal must be `%`, `%{integer}` or `%&`".to_owned()
             }
         }
     }

--- a/compiler/tests/compile-fail/arity.arret
+++ b/compiler/tests/compile-fail/arity.arret
@@ -4,7 +4,7 @@
 (def _ (not-enough-fixed))
       ;^^^^^^^^^^^^^^^^^^ ERROR incorrect number of arguments: wanted 1, have 0
 
-(defn not-enough-fixed-and-rest (_ _ ...) ())
+(defn not-enough-fixed-and-rest (_ & _) ())
 (def _ (not-enough-fixed-and-rest))
       ;^^^^^^^^^^^^^^^^^^^^^^^^^^^ ERROR incorrect number of arguments: wanted at least 1, have 0
 
@@ -22,10 +22,10 @@
   (x 5))
  ;^^^^^ ERROR cannot determine parameter types for top function type `(... -> Bool)`
 
- (defn apply-with-spread (_ [_ Int] _))
- (def _ (apply-with-spread '(1 2) ...))
+ (defn apply-with-rest (_ [_ Int] _))
+ (def _ (apply-with-rest & '(1 2)))
                            ;^^^^^ ERROR `(List Int Int)` is not a `(List Any Int Any)`
- (def _ (apply-with-spread '(1 2 3 4) ...))
+ (def _ (apply-with-rest & '(1 2 3 4)))
                            ;^^^^^^^^^ ERROR `(List Int Int Int Int)` is not a `(List Any Int Any)`
 
 (defn main! ())

--- a/compiler/tests/compile-fail/reference-errors.arret
+++ b/compiler/tests/compile-fail/reference-errors.arret
@@ -6,8 +6,8 @@
 (def _ Str)
       ;^^^ ERROR cannot take the value of a type
 
-(def _ Listof)
-      ;^^^^^^ ERROR cannot take the value of a type
+(def _ List)
+      ;^^^^ ERROR cannot take the value of a type
 
 (def _ ->!)
       ;^^^ ERROR cannot take the value of a type

--- a/compiler/tests/compile-fail/type-checking-errors.arret
+++ b/compiler/tests/compile-fail/type-checking-errors.arret
@@ -54,15 +54,15 @@
 
 (defn bad-apply-in-return-position () -> ()
   (length '(1 2 3)))
-  ;^^^^^^ ERROR `((Listof Any) -> Int)` is not a `(... -> ())
+  ;^^^^^^ ERROR `((List & Any) -> Int)` is not a `(... -> ())
 
-(defn non-list-rest-type (x ...)
+(defn non-list-rest-type (& x)
   (ann x (Vector Any)))
-      ;^ ERROR `(Vector Any)` is not a `(Listof Any)`
+      ;^ ERROR `(Vector Any)` is not a `(List & Any)`
 
-(defn specific-rest-list-type (x ...)
+(defn specific-rest-list-type (& x)
   (ann x (List Int Int Int)))
-      ;^ ERROR `(Listof Int)` is not a `(List Int Int Int)`
+      ;^ ERROR `(List & Int)` is not a `(List Int Int Int)`
 
 ; The compiler should suppress this error as it's a cascade error
 (def depends-on-type-error specific-rest-list-type)
@@ -75,7 +75,7 @@
 
 ; Applying a fun with incorrect polymorphic purity inside a pure context
 (def _ (map println! '(0 1 2 3)))
-           ;^^^^^^^^ ERROR `(Any ... ->! ())` is not a `(Int -> Any)`
+           ;^^^^^^^^ ERROR `(& Any ->! ())` is not a `(Int -> Any)`
 
 ; `input` is used both as a poly `Sym` and a poly `Num`
 (defn conflicting-poly-types #{[A Sym] [B Num]} (input

--- a/compiler/tests/eval-pass/application.arret
+++ b/compiler/tests/eval-pass/application.arret
@@ -5,21 +5,21 @@
 (def _ (filter zero? '(0 1 2 3)))
 
 (defn take-exactly-three (_ _ _) false)
-(defn return-rest (x ...) x)
+(defn return-rest (& x) x)
 (defn polymorphic-identity-function #{T} ([x T]) x)
 
 (defn main! ()
   ; Stress test various ways of passing arguments
   (assert-eq false (take-exactly-three 1 2 3))
-  (assert-eq false (take-exactly-three '(1 2 3) ...))
-  (assert-eq false (take-exactly-three 1 2 '(3) ...))
+  (assert-eq false (take-exactly-three  & '(1 2 3)))
+  (assert-eq false (take-exactly-three 1 2 & '(3)))
 
   ; Make sure we select the return type correctly
   (let [[ret-str Str] (polymorphic-identity-function "Hello polymorphism!")]
     (assert-eq "Hello polymorphism!" ret-str))
 
   ; Make sure we can return our rest argument
-  (let [[rest-list (Listof Any)] (return-rest 1 2 3)]
+  (let [[rest-list (List & Any)] (return-rest 1 2 3)]
     (assert-eq '(1 2 3) rest-list))
 
   ; Treating functions as first-class values

--- a/compiler/tests/eval-pass/binding.arret
+++ b/compiler/tests/eval-pass/binding.arret
@@ -8,7 +8,7 @@
     z))
 
 ; We should be able to infer the type for rest bindings
-(def (x ...) '(1 2 3))
-(def [_ (Listof Int)] x)
+(def (& x) '(1 2 3))
+(def [_ (List & Int)] x)
 
 (defn main! ())

--- a/compiler/tests/eval-pass/divergence.arret
+++ b/compiler/tests/eval-pass/divergence.arret
@@ -56,7 +56,7 @@
     (panic "HERE"))
   5)
 
-(defn panics-inside-app () -> (Listof Any)
+(defn panics-inside-app () -> (List & Any)
   (list (panic "HERE") 2 3))
 
 (defn main! () ->! ()

--- a/compiler/tests/eval-pass/list.arret
+++ b/compiler/tests/eval-pass/list.arret
@@ -9,7 +9,7 @@
 
 (defn test-first-rest ()
   (assert-eq 'one (ann (first '(one two three)) 'one))
-  (assert-eq '(two three) (ann (rest '(one two three)) (Listof Sym)))
+  (assert-eq '(two three) (ann (rest '(one two three)) (List & Sym)))
   (assert-eq () (ann (rest '(one)) '())))
 
 (defn test-cons ()

--- a/compiler/tests/eval-pass/occurrence-typing.arret
+++ b/compiler/tests/eval-pass/occurrence-typing.arret
@@ -30,10 +30,10 @@
     (ann input true)
     (ann input false)))
 
-(defn and-typing ([input (Listof Any)])
+(defn and-typing ([input (List & Any)])
   (if (and (list? input) (nil? input))
     (ann input ())
-    (ann input (List Any Any ...))))
+    (ann input (List Any & Any))))
 
 (defn or-typing ([input (U Sym Str Int)])
   (if (or (sym? input) (str? input))

--- a/compiler/tests/optimise/inliner.arret
+++ b/compiler/tests/optimise/inliner.arret
@@ -1,7 +1,7 @@
 (import [stdlib base])
 (import [stdlib test])
 
-(defn recursive-member? ([item Any] [l (Listof Any)]) -> Bool
+(defn recursive-member? ([item Any] [l (List & Any)]) -> Bool
   (if (nil? l)
     false
     (or

--- a/compiler/tests/optimise/list.arret
+++ b/compiler/tests/optimise/list.arret
@@ -3,7 +3,7 @@
 
 (defn main! ()
   ; This should just need to load the length from the cell
-  (assert-fn-doesnt-contain-op :call (fn ([l (Listof Any)]) -> Int
+  (assert-fn-doesnt-contain-op :call (fn ([l (List & Any)]) -> Int
     (length l)))
 
   ())

--- a/compiler/tests/run-pass/recursion.arret
+++ b/compiler/tests/run-pass/recursion.arret
@@ -1,12 +1,12 @@
 (import [stdlib base])
 (import [stdlib test])
 
-(defn recursive-reverse #{T} ([lst (Listof T)]) -> (Listof T)
+(defn recursive-reverse #{T} ([lst (List & T)]) -> (List & T)
   (if (nil? lst)
     lst
     (concat (recursive-reverse (rest lst)) (list (first lst)))))
 
-(defn even-length? ([l (Listof Any)]) -> Bool
+(defn even-length? ([l (List & Any)]) -> Bool
   (if (nil? l)
     true
     (let [tail (rest l)]

--- a/compiler/ty/intersect.rs
+++ b/compiler/ty/intersect.rs
@@ -407,11 +407,11 @@ mod test {
     #[test]
     fn list_types() {
         assert_disjoint("(List Sym)", "(List Str)");
-        assert_merged("(List Sym Sym)", "(List Any Sym)", "(List Sym ...)");
+        assert_merged("(List Sym Sym)", "(List Any Sym)", "(List & Sym)");
         assert_merged(
             "(List false true)",
             "(List Bool true)",
-            "(List false Bool Any ...)",
+            "(List false Bool & Any)",
         );
 
         assert_disjoint("(List Sym Sym)", "(List Sym)");

--- a/compiler/ty/is_a.rs
+++ b/compiler/ty/is_a.rs
@@ -347,11 +347,11 @@ mod test {
     #[test]
     fn list_types() {
         let empty_list = poly_for_str("()");
-        let listof_any = poly_for_str("(Listof Any)");
-        let listof_int = poly_for_str("(Listof Int)");
+        let listof_any = poly_for_str("(List & Any)");
+        let listof_int = poly_for_str("(List & Int)");
         let two_ints_list = poly_for_str("(List Int Int)");
         let three_ints_list = poly_for_str("(List Int Int Int)");
-        let at_least_one_int_list = poly_for_str("(List Int Int ...)");
+        let at_least_one_int_list = poly_for_str("(List Int & Int)");
 
         assert_eq!(true, ty_ref_is_a(&empty_list, &listof_any));
         assert_eq!(false, ty_ref_is_a(&listof_any, &empty_list));

--- a/compiler/ty/props.rs
+++ b/compiler/ty/props.rs
@@ -87,17 +87,17 @@ mod test {
         assert_eq!(true, str_has_subtypes("Sym"));
         assert_eq!(true, str_has_subtypes("Num"));
 
-        assert_eq!(false, str_has_subtypes("(Any ... -> true)"));
-        assert_eq!(true, str_has_subtypes("(Any ... ->! true)"));
+        assert_eq!(false, str_has_subtypes("(& Any -> true)"));
+        assert_eq!(true, str_has_subtypes("(& Any ->! true)"));
         assert_eq!(true, str_has_subtypes("(Any -> true)"));
-        assert_eq!(true, str_has_subtypes("(Int ... -> true)"));
-        assert_eq!(true, str_has_subtypes("(Any ... -> Any)"));
+        assert_eq!(true, str_has_subtypes("(& Int -> true)"));
+        assert_eq!(true, str_has_subtypes("(& Any -> Any)"));
 
         assert_eq!(true, str_has_subtypes("(Map Sym Int)"));
         assert_eq!(false, str_has_subtypes("(Map Float Int)"));
 
         assert_eq!(true, str_has_subtypes("(List Sym Int)"));
-        assert_eq!(true, str_has_subtypes("(List Str Int ...)"));
+        assert_eq!(true, str_has_subtypes("(List Str & Int)"));
         assert_eq!(false, str_has_subtypes("(List Str Int)"));
 
         assert_eq!(true, str_has_subtypes("(Setof Sym)"));
@@ -122,15 +122,15 @@ mod test {
         assert_eq!(false, str_is_literal("Str"));
         assert_eq!(false, str_is_literal("Sym"));
 
-        assert_eq!(false, str_is_literal("(Any ... -> true)"));
+        assert_eq!(false, str_is_literal("(& Any -> true)"));
 
         assert_eq!(false, str_is_literal("(Map Sym Int)"));
         assert_eq!(false, str_is_literal("(Map false true)"));
 
         assert_eq!(false, str_is_literal("(List Sym Int)"));
-        assert_eq!(false, str_is_literal("(List Str Int ...)"));
+        assert_eq!(false, str_is_literal("(List Str & Int)"));
         assert_eq!(true, str_is_literal("(List true false)"));
-        assert_eq!(false, str_is_literal("(List true false ...)"));
+        assert_eq!(false, str_is_literal("(List true & false)"));
         assert_eq!(true, str_is_literal("()"));
 
         assert_eq!(false, str_is_literal("(Setof ())"));

--- a/compiler/ty/select.rs
+++ b/compiler/ty/select.rs
@@ -492,8 +492,8 @@ mod test {
         let mut stx = scope.select_ctx();
 
         stx.add_evidence(
-            &scope.poly_for_str("(Listof A)"),
-            &scope.poly_for_str("(Listof true)"),
+            &scope.poly_for_str("(List & A)"),
+            &scope.poly_for_str("(List & true)"),
         );
         assert_selected_type(&stx, &poly_a, &scope.poly_for_str("true"));
     }
@@ -506,7 +506,7 @@ mod test {
         let mut stx = scope.select_ctx();
 
         stx.add_evidence(
-            &scope.poly_for_str("(Listof A)"),
+            &scope.poly_for_str("(List & A)"),
             &scope.poly_for_str("(List true false)"),
         );
         assert_selected_type(&stx, &poly_a, &scope.poly_for_str("Bool"));

--- a/compiler/ty/subtract.rs
+++ b/compiler/ty/subtract.rs
@@ -78,7 +78,7 @@ pub fn subtract_ty_refs<M: ty::PM>(
     } else {
         match (minuend_ref, subtrahend_ref) {
             (ty::Ref::Fixed(minuend_ty), ty::Ref::Fixed(subtrahend_ty)) => {
-                // We can substract directly
+                // We can subtract directly
                 subtract_tys(minuend_ty, subtrahend_ref, subtrahend_ty)
             }
             (ty::Ref::Var(_, _), ty::Ref::Fixed(subtrahend_ty)) => {
@@ -139,7 +139,7 @@ mod test {
 
     #[test]
     fn list_subtraction() {
-        assert_subtraction("(List Int Int ...)", "(Listof Int)", "()");
+        assert_subtraction("(List Int & Int)", "(List & Int)", "()");
     }
 
     #[test]

--- a/compiler/ty/unify.rs
+++ b/compiler/ty/unify.rs
@@ -4,7 +4,7 @@
 //! naive implementation to simply detect any duplicate or subtypes and remove them.
 //!
 //! However, while every type can be tested at runtime some type checks are very expensive. A
-//! pathological case would be testing if a long `(Listof Any)` is a `(Listof Int)`. We need to
+//! pathological case would be testing if a long `(List & Any)` is a `(List & Int)`. We need to
 //! allow these checks for completeness but they should be discouraged. To that end, any types
 //! that would be expensive to distinguish at runtime are merged by this code. This ensures in the
 //! general case it should be quick to test for individual members of a union.
@@ -480,18 +480,18 @@ mod test {
 
     #[test]
     fn list_types() {
-        assert_merged("(Listof Any)", "(List Any)", "(Listof Any)");
+        assert_merged("(List & Any)", "(List Any)", "(List & Any)");
         assert_discerned("(List Any)", "(List Any Any)");
         assert_merged("(List (RawU Sym Str))", "(List Sym)", "(List Str)");
-        assert_discerned("(List Str)", "(List Str Str Str ...)");
+        assert_discerned("(List Str)", "(List Str Str & Str)");
         assert_merged(
-            "(List Int (RawU Float Sym Str) ...)",
-            "(List Int Sym ...)",
-            "(List Int Float Str ...)",
+            "(List Int & (RawU Float Sym Str))",
+            "(List Int & Sym)",
+            "(List Int Float & Str)",
         );
 
-        assert_merged("(Listof Int)", "(List Int Int ...)", "(List)");
-        assert_merged("(Listof Sym)", "(List)", "(List Sym Sym ...)");
+        assert_merged("(List & Int)", "(List Int & Int)", "(List)");
+        assert_merged("(List & Sym)", "(List)", "(List Sym & Sym)");
     }
 
     #[test]

--- a/compiler/typeck/infer.rs
+++ b/compiler/typeck/infer.rs
@@ -1805,11 +1805,11 @@ mod test {
         assert_type_for_expr("false", "(sym? false)");
 
         assert_type_for_expr("Int", "((fn #{A} ([value A]) -> A value) 1)");
-        assert_type_for_expr("'foo", "((fn #{A} ([value A]) -> A value) '(foo) ...)");
+        assert_type_for_expr("'foo", "((fn #{A} ([value A]) -> A value) & '(foo))");
 
         assert_type_for_expr(
-            "(Listof Bool)",
-            "((fn #{A} ([rest A] ...) -> (Listof A) rest) true false)",
+            "(List & Bool)",
+            "((fn #{A} (& [rest A]) -> (List & A) rest) true false)",
         );
 
         assert_type_for_expr(
@@ -1909,7 +1909,7 @@ mod test {
         assert_type_for_expr("Int", "(let [(x) '(1)] x)");
         assert_type_for_expr(
             "(List true false)",
-            "(let [(_ rest ...) '(1 true false)] rest)",
+            "(let [(_ & rest) '(1 true false)] rest)",
         );
     }
 
@@ -1920,9 +1920,9 @@ mod test {
 
     #[test]
     fn ty_pred() {
-        assert_type_for_expr("true", "(sym? '(foo) ...)");
+        assert_type_for_expr("true", "(sym? & '(foo))");
         assert_type_for_expr("true", "(sym? 'foo)");
-        assert_type_for_expr("false", "(int? '(foo) ...)");
+        assert_type_for_expr("false", "(int? & '(foo))");
         assert_type_for_expr("false", "(int? 'bar)");
     }
 

--- a/stdlib/arret/base.arret
+++ b/stdlib/arret/base.arret
@@ -2,7 +2,7 @@
 (export def let fn if quote export ... defmacro letmacro macro-rules deftype compile-error do =)
 
 (import [arret internal types])
-(export Any Bool Str Sym Int Float Num Char List Listof Vector Vectorof Setof Map U -> ->! str?
+(export Any Bool Str Sym Int Float Num Char List Vector Vectorof Setof Map U -> ->! str? sym?
         sym? bool? num? int? float? char? list? vector? set? map? fn? nil?)
 
 (import [stdlib rust])
@@ -21,7 +21,7 @@
 ))
 
 (export list)
-(defn list #{A} ([l A] ...) -> (Listof A)
+(defn list #{A} (& [l A]) -> (List & A)
   l)
 
 (export when)
@@ -61,11 +61,11 @@
 ))
 
 (export first)
-(defn first #{T} (([head T] _ ...)) -> T
+(defn first #{T} (([head T] & _)) -> T
   head)
 
 (export rest)
-(defn rest #{T} ((_ [tail T] ...)) -> (Listof T)
+(defn rest #{T} ((_ & [tail T])) -> (List & T)
   tail)
 
 (export zero?)

--- a/stdlib/rust/lib.rs
+++ b/stdlib/rust/lib.rs
@@ -29,7 +29,7 @@ use runtime::boxed;
 use runtime::boxed::refs::Gc;
 use runtime::task::Task;
 
-#[rfi_derive::rust_fun("(Any ... -> (U))")]
+#[rfi_derive::rust_fun("(& Any -> (U))")]
 pub fn stdlib_panic(task: &mut Task, values: Gc<boxed::List<boxed::Any>>) -> Never {
     use std::str;
 

--- a/stdlib/rust/list.rs
+++ b/stdlib/rust/list.rs
@@ -8,12 +8,12 @@ use runtime::task::Task;
 
 use rfi_derive;
 
-#[rfi_derive::rust_fun("((Listof Any) -> Int)")]
+#[rfi_derive::rust_fun("((List & Any) -> Int)")]
 pub fn stdlib_length(input: Gc<boxed::List<boxed::Any>>) -> i64 {
     input.len() as i64
 }
 
-#[rfi_derive::rust_fun("(All #{H T} H (Listof T) -> (List H T ...))")]
+#[rfi_derive::rust_fun("(All #{H T} H (List & T) -> (List H & T))")]
 pub fn stdlib_cons(
     task: &mut Task,
     head: Gc<boxed::Any>,
@@ -22,7 +22,7 @@ pub fn stdlib_cons(
     boxed::Pair::new(task, (head, tail)).as_top_pair()
 }
 
-#[rfi_derive::rust_fun("(All #{I O [->_ ->!]} (I ->_ O) (Listof I) ->_ (Listof O))")]
+#[rfi_derive::rust_fun("(All #{I O [->_ ->!]} (I ->_ O) (List & I) ->_ (List & O))")]
 pub fn stdlib_map(
     task: &mut Task,
     mapper: callback::Callback<
@@ -37,7 +37,7 @@ pub fn stdlib_map(
     boxed::List::new(task, output_vec.into_iter())
 }
 
-#[rfi_derive::rust_fun("(All #{T [->_ ->!]} (T ->_ Bool) (Listof T) ->_ (Listof T))")]
+#[rfi_derive::rust_fun("(All #{T [->_ ->!]} (T ->_ Bool) (List & T) ->_ (List & T))")]
 pub fn stdlib_filter(
     task: &mut Task,
     filter: callback::Callback<extern "C" fn(&mut Task, boxed::Closure, Gc<boxed::Any>) -> bool>,
@@ -51,7 +51,7 @@ pub fn stdlib_filter(
     boxed::List::new(task, output_vec.into_iter())
 }
 
-#[rfi_derive::rust_fun("(All #{I O [->_ ->!]} (O I ->_ O) O (Listof I) ->_ O)")]
+#[rfi_derive::rust_fun("(All #{I O [->_ ->!]} (O I ->_ O) O (List & I) ->_ O)")]
 pub fn stdlib_fold(
     task: &mut Task,
     folder: callback::Callback<
@@ -65,7 +65,7 @@ pub fn stdlib_fold(
         .fold(initial, |acc, elem| folder.apply(task, acc, elem))
 }
 
-#[rfi_derive::rust_fun("(All #{T} (Listof T) ... -> (Listof T))")]
+#[rfi_derive::rust_fun("(All #{T} & (List & T) -> (List & T))")]
 pub fn stdlib_concat(
     task: &mut Task,
     lists: Gc<boxed::List<boxed::List<boxed::Any>>>,
@@ -84,7 +84,7 @@ pub fn stdlib_concat(
     boxed::List::new_with_tail(task, head_values.into_iter(), list_iter.next().unwrap())
 }
 
-#[rfi_derive::rust_fun("(Any (Listof Any) -> Bool)")]
+#[rfi_derive::rust_fun("(Any (List & Any) -> Bool)")]
 pub fn stdlib_member_p(needle: Gc<boxed::Any>, haystack: Gc<boxed::List<boxed::Any>>) -> bool {
     haystack.iter().any(|member| member == needle)
 }

--- a/stdlib/rust/math.rs
+++ b/stdlib/rust/math.rs
@@ -63,19 +63,19 @@ where
     boxed::Int::new(task, int_acc).as_num()
 }
 
-#[rfi_derive::rust_fun("(All #{[N Num]} N ... -> N)")]
+#[rfi_derive::rust_fun("(All #{[N Num]} & N -> N)")]
 pub fn stdlib_add(task: &mut Task, operands: Gc<boxed::List<boxed::Num>>) -> Gc<boxed::Num> {
     use std::ops::Add;
     fold_num_op(task, operands.iter(), 0, i64::add, f64::add)
 }
 
-#[rfi_derive::rust_fun("(All #{[N Num]} N ... -> N)")]
+#[rfi_derive::rust_fun("(All #{[N Num]} & N -> N)")]
 pub fn stdlib_mul(task: &mut Task, operands: Gc<boxed::List<boxed::Num>>) -> Gc<boxed::Num> {
     use std::ops::Mul;
     fold_num_op(task, operands.iter(), 1, i64::mul, f64::mul)
 }
 
-#[rfi_derive::rust_fun("(All #{[N Num]} N N ... -> N)")]
+#[rfi_derive::rust_fun("(All #{[N Num]} N & N -> N)")]
 pub fn stdlib_sub(
     task: &mut Task,
     initial_num: Gc<boxed::Num>,
@@ -101,7 +101,7 @@ pub fn stdlib_sub(
     }
 }
 
-#[rfi_derive::rust_fun("(Float Float ... -> Float)")]
+#[rfi_derive::rust_fun("(Float & Float -> Float)")]
 pub fn stdlib_div(initial_float: f64, rest: Gc<boxed::List<boxed::Float>>) -> f64 {
     if rest.is_empty() {
         initial_float.recip()

--- a/stdlib/rust/testing.rs
+++ b/stdlib/rust/testing.rs
@@ -32,7 +32,7 @@ pub fn stdlib_heap_alloc_count(
 }
 
 // TODO: This should return a `Set` once they're better supported
-#[rfi_derive::rust_fun("((... ->! Any) -> (Listof Sym))")]
+#[rfi_derive::rust_fun("((... ->! Any) -> (List & Sym))")]
 pub fn stdlib_fn_op_categories(_value: Gc<boxed::FunThunk>) -> Gc<boxed::List<boxed::Sym>> {
     panic!("cannot call `(fn-op-categories)` at runtime")
 }

--- a/stdlib/rust/write.rs
+++ b/stdlib/rust/write.rs
@@ -11,7 +11,7 @@ use rfi_derive;
 
 use crate::pretty_print::pretty_print;
 
-#[rfi_derive::rust_fun("(Any ... ->! ())")]
+#[rfi_derive::rust_fun("(& Any ->! ())")]
 pub fn stdlib_print(task: &mut Task, values: Gc<boxed::List<boxed::Any>>) {
     let mut output = io::stdout();
 
@@ -20,7 +20,7 @@ pub fn stdlib_print(task: &mut Task, values: Gc<boxed::List<boxed::Any>>) {
     }
 }
 
-#[rfi_derive::rust_fun("(Any ... ->! ())")]
+#[rfi_derive::rust_fun("(& Any ->! ())")]
 pub fn stdlib_println(task: &mut Task, values: Gc<boxed::List<boxed::Any>>) {
     let mut output = io::stdout();
 

--- a/syntax/anon_fun.rs
+++ b/syntax/anon_fun.rs
@@ -18,7 +18,7 @@ fn visit_arg_literals(found_arity: &mut FoundArity, datum: Datum) -> Result<Datu
                         found_arity.fixed_args = std::cmp::max(found_arity.fixed_args, 1);
                         Ok(Datum::Sym(span, "%1".into()))
                     }
-                    "..." => {
+                    "&" => {
                         found_arity.has_rest = true;
                         Ok(Datum::Sym(span, name))
                     }
@@ -70,8 +70,8 @@ pub fn convert_anon_fun(outer_span: Span, body_data: impl Iterator<Item = Datum>
 
     if found_arity.has_rest {
         param_list.extend(
-            iter::once(Datum::Sym(outer_span, "%...".into()))
-                .chain(iter::once(Datum::Sym(outer_span, "...".into()))),
+            iter::once(Datum::Sym(outer_span, "&".into()))
+                .chain(iter::once(Datum::Sym(outer_span, "%&".into()))),
         );
     }
 
@@ -176,9 +176,9 @@ mod test {
 
     #[test]
     fn rest_fun() {
-        let j = "%1 %...";
-        let t = "^^     ";
-        let u = "   ^^^^";
+        let j = "%1 %&";
+        let t = "^^   ";
+        let u = "   ^^";
 
         let body_data = data_from_str(j).unwrap();
 
@@ -190,15 +190,15 @@ mod test {
                     EMPTY_SPAN,
                     Box::new([
                         Datum::Sym(EMPTY_SPAN, "%1".into()),
-                        Datum::Sym(EMPTY_SPAN, "%...".into()),
-                        Datum::Sym(EMPTY_SPAN, "...".into()),
+                        Datum::Sym(EMPTY_SPAN, "&".into()),
+                        Datum::Sym(EMPTY_SPAN, "%&".into()),
                     ]),
                 ),
                 Datum::List(
                     EMPTY_SPAN,
                     Box::new([
                         Datum::Sym(t2s(t), "%1".into()),
-                        Datum::Sym(t2s(u), "%...".into()),
+                        Datum::Sym(t2s(u), "%&".into()),
                     ]),
                 ),
             ]),


### PR DESCRIPTION
Instead of `fixed rest ...` use `fixed & rest`. This has a few advantages:

- It minimises arbitrary differences with Clojure.

- It distinguishes zero or more matches in macros (`...`) which can appear anywhere with rest lists which can only appear at the end. At one point these were intended to be unified but that's been long abandoned.

- It makes top fun types more visually distinct from rest fun types.

- It's more compact than the `...`. This allows us to kill the `Listof` type constructor as its now the same length as the `List` version.

Unlike isn't a bound prim - see #67 for an explanation