### PR TITLE
De-prim ellipsis

### DIFF
--- a/compiler/hir/lowering.rs
+++ b/compiler/hir/lowering.rs
@@ -123,7 +123,7 @@ fn lower_macro(scope: &mut Scope, self_datum: NsDatum, transformer_spec: NsDatum
         ));
     };
 
-    let mac = lower_macro_rules(scope, macro_rules_data)?;
+    let mac = lower_macro_rules(macro_rules_data)?;
 
     if self_ident.name() != "_" {
         scope.insert_binding(self_span, self_ident, Binding::Macro(MacroId::new(mac)))?;
@@ -438,7 +438,7 @@ fn lower_expr_prim_apply(
         }
         Prim::Do => lower_body(scope, span, arg_iter),
         Prim::CompileError => Err(lower_user_compile_error(span, arg_iter)),
-        Prim::Ellipsis | Prim::MacroRules | Prim::All => Err(Error::new(span, ErrorKind::PrimRef)),
+        Prim::MacroRules | Prim::All => Err(Error::new(span, ErrorKind::PrimRef)),
     }
 }
 

--- a/compiler/hir/macros/expander.rs
+++ b/compiler/hir/macros/expander.rs
@@ -88,7 +88,7 @@ impl<'scope> ExpandCtx<'scope> {
         let mut result: Vec<NsDatum> = vec![];
 
         while !templates.is_empty() {
-            if starts_with_zero_or_more(self.scope, templates) {
+            if starts_with_zero_or_more(templates) {
                 let mut expanded = self.expand_zero_or_more(cursor, &templates[0]);
                 result.append(&mut expanded);
 
@@ -111,7 +111,7 @@ impl<'scope> ExpandCtx<'scope> {
         span: Span,
         templates: &[NsDatum],
     ) -> NsDatum {
-        if is_escaped_ellipsis(self.scope, templates) {
+        if is_escaped_ellipsis(templates) {
             templates[1].clone()
         } else {
             NsDatum::List(span, self.expand_slice(cursor, templates))

--- a/compiler/hir/macros/matcher.rs
+++ b/compiler/hir/macros/matcher.rs
@@ -2,20 +2,17 @@ use std::result;
 
 use crate::hir::macros::{starts_with_zero_or_more, MatchData, Rule};
 use crate::hir::ns::{Ident, NsDatum};
-use crate::hir::scope::Scope;
 
-struct MatchCtx<'scope, 'data> {
-    scope: &'scope Scope,
+struct MatchCtx<'data> {
     match_data: MatchData<'data>,
 }
 
 type Result<T> = result::Result<T, ()>;
 type MatchVisitResult = result::Result<(), ()>;
 
-impl<'scope, 'data> MatchCtx<'scope, 'data> {
-    fn new(scope: &'scope Scope) -> Self {
+impl<'data> MatchCtx<'data> {
+    fn new() -> Self {
         MatchCtx {
-            scope,
             match_data: MatchData::new(),
         }
     }
@@ -62,7 +59,6 @@ impl<'scope, 'data> MatchCtx<'scope, 'data> {
             .iter()
             .map(|arg| {
                 let mut subcontext = MatchCtx {
-                    scope: self.scope,
                     match_data: MatchData::new(),
                 };
 
@@ -81,7 +77,7 @@ impl<'scope, 'data> MatchCtx<'scope, 'data> {
         mut args: &'data [NsDatum],
     ) -> MatchVisitResult {
         loop {
-            if starts_with_zero_or_more(self.scope, patterns) {
+            if starts_with_zero_or_more(patterns) {
                 let rest_patterns_len = patterns.len() - 2;
 
                 if args.len() < rest_patterns_len {
@@ -126,10 +122,9 @@ impl<'scope, 'data> MatchCtx<'scope, 'data> {
 }
 
 pub fn match_rule<'data>(
-    scope: &Scope,
     rule: &'data Rule,
     arg_data: &'data [NsDatum],
 ) -> Result<MatchData<'data>> {
-    let mcx = MatchCtx::new(scope);
+    let mcx = MatchCtx::new();
     mcx.visit_rule(rule, arg_data)
 }

--- a/compiler/hir/prim.rs
+++ b/compiler/hir/prim.rs
@@ -30,7 +30,6 @@ export_prims!(
     ("export", Export),
     ("defmacro", DefMacro),
     ("letmacro", LetMacro),
-    ("...", Ellipsis),
     ("macro-rules", MacroRules),
     ("deftype", DefType),
     ("lettype", LetType),

--- a/compiler/hir/types.rs
+++ b/compiler/hir/types.rs
@@ -134,15 +134,17 @@ fn lower_fun_cons(
 
     let top_fun = ty::TopFun::new(purity, ret_ty);
 
-    if arg_iter.len() == 1
-        && scope.get_datum(&arg_iter.as_slice()[0]) == Some(&Binding::Prim(Prim::Ellipsis))
-    {
-        // Top function type in the form `(... -> ReturnType)`
-        Ok(top_fun.into())
-    } else {
-        let params = lower_list_cons(scope, arg_iter)?;
-        Ok(ty::Fun::new(purity::PVarIds::new(), ty::TVarIds::new(), top_fun, params).into())
+    if arg_iter.len() == 1 {
+        if let NsDatum::Ident(_, ident) = &arg_iter.as_slice()[0] {
+            if ident.name() == "..." {
+                // Top function type in the form `(... -> ReturnType)`
+                return Ok(top_fun.into());
+            }
+        }
     }
+
+    let params = lower_list_cons(scope, arg_iter)?;
+    Ok(ty::Fun::new(purity::PVarIds::new(), ty::TVarIds::new(), top_fun, params).into())
 }
 
 fn lower_ty_cons_apply(

--- a/stdlib/arret/base.arret
+++ b/stdlib/arret/base.arret
@@ -1,5 +1,5 @@
 (import [arret internal primitives])
-(export def let fn if quote export ... defmacro letmacro macro-rules deftype compile-error do =)
+(export def let fn if quote export defmacro letmacro macro-rules deftype compile-error do =)
 
 (import [arret internal types])
 (export Any Bool Str Sym Int Float Num Char List Vector Vectorof Setof Map U -> ->! str? sym?


### PR DESCRIPTION
This is consistent with `_` and `&` now. In addition to simplifying the
macro implementation this should require fewer scope lookups.