### PR TITLE
Add macro literal ident escape

### DIFF
--- a/compiler/hir/macros/checker.rs
+++ b/compiler/hir/macros/checker.rs
@@ -4,7 +4,7 @@ use std::result;
 use syntax::span::{Span, EMPTY_SPAN};
 
 use crate::hir::error::{Error, ErrorKind, Result};
-use crate::hir::macros::{is_escaped_ellipsis, starts_with_zero_or_more};
+use crate::hir::macros::{get_escaped_ident, starts_with_zero_or_more};
 use crate::hir::ns::{Ident, NsDatum};
 
 #[derive(PartialEq, Debug)]
@@ -170,7 +170,8 @@ impl<'data> FindVarsCtx<'data> {
         pattern_vars: &mut FoundVars<'data>,
         patterns: &'data [NsDatum],
     ) -> FindVarsResult {
-        if self.input_type == FindVarsInputType::Template && is_escaped_ellipsis(patterns) {
+        if get_escaped_ident(patterns).is_some() {
+            // This isn't actually a list
             Ok(())
         } else {
             self.visit_seq(pattern_vars, patterns)

--- a/compiler/hir/macros/expander.rs
+++ b/compiler/hir/macros/expander.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use syntax::span::Span;
 
 use crate::hir::macros::checker::VarLinks;
-use crate::hir::macros::{is_escaped_ellipsis, starts_with_zero_or_more, MatchData};
+use crate::hir::macros::{get_escaped_ident, starts_with_zero_or_more, MatchData};
 use crate::hir::ns::{Ident, NsDatum, NsId};
 use crate::hir::scope::Scope;
 
@@ -111,8 +111,8 @@ impl<'scope> ExpandCtx<'scope> {
         span: Span,
         templates: &[NsDatum],
     ) -> NsDatum {
-        if is_escaped_ellipsis(templates) {
-            templates[1].clone()
+        if let Some(ident) = get_escaped_ident(templates) {
+            NsDatum::Ident(span, ident.clone())
         } else {
             NsDatum::List(span, self.expand_slice(cursor, templates))
         }

--- a/compiler/hir/macros/mod.rs
+++ b/compiler/hir/macros/mod.rs
@@ -51,20 +51,23 @@ impl Macro {
     }
 }
 
-fn is_ellipsis_datum(datum: &NsDatum) -> bool {
-    if let NsDatum::Ident(_, ident) = datum {
+fn starts_with_zero_or_more(data: &[NsDatum]) -> bool {
+    if let Some(NsDatum::Ident(_, ident)) = data.get(1) {
         ident.name() == "..."
     } else {
         false
     }
 }
 
-fn starts_with_zero_or_more(data: &[NsDatum]) -> bool {
-    data.get(1).map(|d| is_ellipsis_datum(d)).unwrap_or(false)
-}
-
-fn is_escaped_ellipsis(data: &[NsDatum]) -> bool {
-    data.len() == 2 && data.iter().all(|d| is_ellipsis_datum(d))
+fn get_escaped_ident(data: &[NsDatum]) -> Option<&Ident> {
+    match data {
+        [NsDatum::Ident(_, ellipsis_ident), NsDatum::Ident(_, escaped_ident)]
+            if ellipsis_ident.name() == "..." =>
+        {
+            Some(escaped_ident)
+        }
+        _ => None,
+    }
 }
 
 fn lower_macro_rule_datum(rule_datum: NsDatum) -> Result<Rule> {

--- a/compiler/tests/eval-pass/macros.arret
+++ b/compiler/tests/eval-pass/macros.arret
@@ -81,4 +81,12 @@
   (letmacro [set-+-to-* (macro-rules [(body) (let [+ *] body)])]
     (assert-eq 2 (set-+-to-* (+ 1 1))))
 
+  ; Use the `(... ident)` literal syntax
+  ; This uses `&` as it's a common candidate for a literal it could be an arbitrary symbol
+  (letmacro [match-literal-& (macro-rules
+                              [((... &)) '(... literal-ampersand)]
+                              [(&) '(... var-ampersand)])]
+    (assert-eq 'literal-ampersand (match-literal-& &))
+    (assert-eq 'var-ampersand (match-literal-& 1)))
+
   ())


### PR DESCRIPTION
PR #65 removed support for R7RS style literals in macro definitions. These were a list of identifiers that were considered literals for the whole macro body. This simplified our syntax and implementation and allowed using keywords in their place.

However, there are a few operator/punctuation idents that we may want to match on - e.g. `_`, `&` and `...`. These are technically idents so right now matching is impossible as they'll be treated as variables.

However, R7RS already has a escape for `...` - `(... ...)`. This works because it's illegal for the ellipsis to appear at the beginning of the list. This extends that escape in two ways:

1. Allow arbitrary idents as the second member of the list, e.g. `(... &)`

2. Allow the escapes to appear in both the pattern and template and handle them in the matcher

The implementation is simple but the syntax is ugly. However, this is intended to be used sparingly as an escape hatch and reuses existing macro syntax.