### PR TITLE
Bring back EMPTY_SPAN

### DIFF
--- a/compiler/lib.rs
+++ b/compiler/lib.rs
@@ -101,7 +101,7 @@ pub fn program_to_evaluable(
     )
     .map_err(|err| vec![err.into()])?;
 
-    let mut ehx = EvalHirCtx::new(ccx.source_loader(), ccx.enable_optimisations());
+    let mut ehx = EvalHirCtx::new(ccx.enable_optimisations());
     let mut rfi_libraries = vec![];
 
     for import in &entry_module.imports {

--- a/compiler/mir/value/synthetic_fun.rs
+++ b/compiler/mir/value/synthetic_fun.rs
@@ -8,7 +8,7 @@ use crate::hir;
 use crate::hir::var_id::VarIdAlloc;
 use crate::mir::env_values::EnvValues;
 use crate::mir::value;
-use crate::source::SourceLoader;
+use crate::source::EMPTY_SPAN;
 use crate::ty;
 use crate::ty::purity;
 use crate::ty::purity::Purity;
@@ -229,7 +229,6 @@ fn new_field_accessor_arret_fun(
 }
 
 pub struct SyntheticFuns {
-    synthetic_span: Span,
     eq_pred_arret_fun: Option<value::ArretFun>,
     ty_pred_arret_fun: HashMap<ty::pred::TestTy, value::ArretFun>,
     record_cons_arret_fun: HashMap<record::ConsId, value::ArretFun>,
@@ -237,10 +236,8 @@ pub struct SyntheticFuns {
 }
 
 impl SyntheticFuns {
-    pub fn new(sl: &SourceLoader) -> Self {
+    pub fn new() -> Self {
         Self {
-            synthetic_span: sl.span_for_rust_source_file(file!()),
-
             eq_pred_arret_fun: None,
             ty_pred_arret_fun: HashMap::new(),
             record_cons_arret_fun: HashMap::new(),
@@ -249,26 +246,20 @@ impl SyntheticFuns {
     }
 
     pub fn eq_pred_arret_fun(&mut self) -> &value::ArretFun {
-        let span = self.synthetic_span;
-
         self.eq_pred_arret_fun
-            .get_or_insert_with(|| new_eq_pred_arret_fun(span))
+            .get_or_insert_with(|| new_eq_pred_arret_fun(EMPTY_SPAN))
     }
 
     pub fn ty_pred_arret_fun(&mut self, test_ty: ty::pred::TestTy) -> &value::ArretFun {
-        let span = self.synthetic_span;
-
         self.ty_pred_arret_fun
             .entry(test_ty.clone())
-            .or_insert_with(|| new_ty_pred_arret_fun(span, test_ty))
+            .or_insert_with(|| new_ty_pred_arret_fun(EMPTY_SPAN, test_ty))
     }
 
     pub fn record_cons_arret_fun(&mut self, cons: &record::ConsId) -> &value::ArretFun {
-        let span = self.synthetic_span;
-
         self.record_cons_arret_fun
             .entry(cons.clone())
-            .or_insert_with(|| new_record_cons_arret_fun(span, cons))
+            .or_insert_with(|| new_record_cons_arret_fun(EMPTY_SPAN, cons))
     }
 
     pub fn field_accessor_arret_fun(
@@ -276,11 +267,10 @@ impl SyntheticFuns {
         cons: &record::ConsId,
         field_index: usize,
     ) -> &value::ArretFun {
-        let span = self.synthetic_span;
         let lookup_key = (cons.clone(), field_index);
 
         self.field_accessor_arret_fun
             .entry(lookup_key)
-            .or_insert_with(|| new_field_accessor_arret_fun(span, cons, field_index))
+            .or_insert_with(|| new_field_accessor_arret_fun(EMPTY_SPAN, cons, field_index))
     }
 }

--- a/compiler/repl.rs
+++ b/compiler/repl.rs
@@ -87,7 +87,7 @@ impl<'ccx> ReplEngine<'ccx> {
             seen_modules: HashSet::new(),
             inferred_module_vars: HashMap::new(),
 
-            ehx: EvalHirCtx::new(ccx.source_loader(), ccx.enable_optimisations()),
+            ehx: EvalHirCtx::new(ccx.enable_optimisations()),
         }
     }
 

--- a/compiler/source.rs
+++ b/compiler/source.rs
@@ -8,7 +8,6 @@ use codespan_reporting;
 use arret_syntax::datum::Datum;
 use arret_syntax::span::{FileId, Span};
 
-#[cfg(test)]
 pub const EMPTY_SPAN: Span = Span::new(None, 0, 0);
 
 #[derive(Clone)]
@@ -153,30 +152,6 @@ impl SourceLoader {
             parsed: data_from_str(Some(file_id), source.as_ref()),
             source,
         }
-    }
-
-    /// Creates an artificial span for a Rust source file
-    ///
-    /// This points to a zero length span with the specified filename. It's intended for IR and code
-    /// generated from the compiler that can't be directly attributed to input Arret code. For
-    /// example, the compiler will generate synthetic functions on demand that can be shared between
-    /// multiple call sites.
-    pub fn span_for_rust_source_file(&self, filename: &'static str) -> Span {
-        let reportable_file = ReportableFile {
-            filename: filename.into(),
-            source: SourceText::Static(""),
-            line_offsets: vec![],
-        };
-
-        let file_index = {
-            let mut files_write = self.files.write().unwrap();
-
-            files_write.push(reportable_file);
-            files_write.len()
-        };
-
-        let file_id = FileId::new(file_index as u32).unwrap();
-        Span::new(Some(file_id), 0, 0)
     }
 
     pub fn files(&self) -> ReportableFiles<'_> {


### PR DESCRIPTION
One of the codespan upgrades made `EMPTY_SPAN` impossible so a lot of
effort was made to eradicate it throughout the codebase. While most of
these changes fixed places where we could attribute to Arret source,
there were two places in MIR where that had no source location. This
caused us to create synthetic spans pointing to Rust source.

While a good idea, this involves a lot of code and variable passing. It
also increases contention on our files lock. Kill it completely and put
`EMPTY_SPAN` back.