### PR TITLE
Remove boxed Vector values

### DIFF
--- a/compiler/mir/value/build_reg.rs
+++ b/compiler/mir/value/build_reg.rs
@@ -165,7 +165,6 @@ fn const_to_reg(
         }
         (boxed::AnySubtype::Vector(vector_ref), abitype::ABIType::Boxed(to_abi_type)) => {
             let element_regs = vector_ref
-                .values()
                 .iter()
                 .map(|element_ref| {
                     const_to_reg(

--- a/runtime/boxed/heap/collect.rs
+++ b/runtime/boxed/heap/collect.rs
@@ -152,7 +152,7 @@ impl StrongPass {
                     let vec_ref =
                         unsafe { &mut *(box_ref.as_mut_ptr() as *mut boxed::Vector<boxed::Any>) };
 
-                    for elem_ref in vec_ref.values_mut() {
+                    for elem_ref in vec_ref.iter_mut() {
                         Self::visit_any_box(old_heap, new_heap, elem_ref);
                     }
                 }

--- a/stdlib/rust/vector.rs
+++ b/stdlib/rust/vector.rs
@@ -17,8 +17,6 @@ pub fn stdlib_vector_ref(
     vector: Gc<boxed::Vector<boxed::Any>>,
     index: i64,
 ) -> Gc<boxed::Any> {
-    let values = vector.values();
-
     let usize_index = if index < 0 {
         task.panic(format!("index {} is negative", index));
         unreachable!("returned from panic")
@@ -26,16 +24,17 @@ pub fn stdlib_vector_ref(
         index as usize
     };
 
-    if usize_index >= values.len() {
-        task.panic(format!(
-            "index {} out of bounds for vector of length {}",
-            usize_index,
-            values.len()
-        ));
-        unreachable!("returned from panic")
+    match vector.get(usize_index) {
+        Some(value) => *value,
+        None => {
+            task.panic(format!(
+                "index {} out of bounds for vector of length {}",
+                usize_index,
+                vector.len()
+            ));
+            unreachable!("returned from panic")
+        }
     }
-
-    values[usize_index]
 }
 
 #[arret_rfi_derive::rust_fun("((Vectorof Any) -> Int)")]
@@ -48,5 +47,5 @@ pub fn stdlib_vector_to_list(
     task: &mut Task,
     vector: Gc<boxed::Vector<boxed::Any>>,
 ) -> Gc<boxed::List<boxed::Any>> {
-    boxed::List::new(task, vector.values().iter().cloned())
+    boxed::List::new(task, vector.iter().cloned())
 }


### PR DESCRIPTION
This depends on the vector being laid out sequentially in memory which we can't support for persistent vectors. Instead, use the standard Rust `iter`, `iter_mut` and `get` conventions which abstract over the memory layout.

In all cases this actually improves the consumer code.