### PR TITLE
Test printing multiple args

### DIFF
--- a/compiler/tests/run-error/impure-panic.arret
+++ b/compiler/tests/run-error/impure-panic.arret
@@ -1,4 +1,5 @@
 (import [stdlib base])
+(import [stdlib test])
 
 (defn main! () ->! ()
-  (panic! "This should impurely panic"))
+  (panic! "Impure " \p \a (black-box! \n) (black-box! \i) \c (black-box! \!)))

--- a/compiler/tests/run-error/impure-panic.stderr
+++ b/compiler/tests/run-error/impure-panic.stderr
@@ -1,1 +1,1 @@
-This should impurely panic
+Impure panic!

--- a/compiler/tests/run-error/pure-panic.arret
+++ b/compiler/tests/run-error/pure-panic.arret
@@ -1,4 +1,5 @@
 (import [stdlib base])
+(import [stdlib test])
 
 (defn main! () ->! ()
-  (panic "This should purely panic"))
+  (panic "Pure " \p \a (black-box \n) (black-box \i) \c (black-box \!)))

--- a/compiler/tests/run-error/pure-panic.stderr
+++ b/compiler/tests/run-error/pure-panic.stderr
@@ -1,1 +1,1 @@
-This should purely panic
+Pure panic!

--- a/compiler/tests/run-pass/write.arret
+++ b/compiler/tests/run-pass/write.arret
@@ -20,15 +20,18 @@
 (defn test-write-to-str! () ->! ()
   (assert-eq! "" (print-str))
   (assert-eq! "" (write-str))
-  
+
   (assert-eq! "hello" (print-str 'hello))
   (assert-eq! "hello" (write-str 'hello))
 
   (assert-eq! "Hello, world!" (print-str "Hello, world!"))
   (assert-eq! "\"Hello, world!\"" (write-str "Hello, world!"))
-  
+
   (assert-eq! " " (print-str \space))
-  (assert-eq! "\\space" (write-str \space)))
+  (assert-eq! "\\space" (write-str \space))
+
+  (assert-eq! "123456" (print-str 1 2 (black-box! 3) (black-box! 4) 5 (black-box! 6)))
+  (assert-eq! "1 2 3 4 5 6" (write-str 1 2 (black-box! 3) (black-box! 4) 5 (black-box! 6))))
 
 (defn main! () ->! ()
   (test-write-to-stdout!)


### PR DESCRIPTION
This tests the spacing rules for `print-str`, `write-str`, `panic` and
`panic!`. These vary between the writes & prints and are currently
untested.