### PR TITLE
Add partial pretty printing during eval

### DIFF
--- a/compiler/mir/intrinsic/mod.rs
+++ b/compiler/mir/intrinsic/mod.rs
@@ -4,6 +4,8 @@ mod math;
 mod num_utils;
 mod number;
 mod panics;
+mod partial_print;
+mod print;
 mod testing;
 mod vector;
 
@@ -90,6 +92,10 @@ define_build_intrinsics! {
     // optimised away.
     "panic" => panics::panics,
     "panic!" => panics::panics,
+
+    "print!" => print::print,
+    "println!" => print::print,
+    "print-str" => print::print,
 
     "vector-length" => vector::vector_length,
     "vector-ref" => vector::vector_ref,

--- a/compiler/mir/intrinsic/partial_print.rs
+++ b/compiler/mir/intrinsic/partial_print.rs
@@ -1,0 +1,88 @@
+use arret_syntax::span::Span;
+
+use arret_runtime::boxed;
+
+use crate::mir::builder::Builder;
+use crate::mir::eval_hir::EvalHirCtx;
+use crate::mir::value::to_const::value_to_const;
+use crate::mir::value::Value;
+
+pub enum PartialPrint {
+    Constant(String),
+    SimplifiedArgs(Box<[Value]>),
+}
+
+impl PartialPrint {
+    /// Converts the partial print to an arg list suitable for passing to a stdlib print function
+    pub fn into_arg_list_value(self, ehx: &mut EvalHirCtx) -> Value {
+        match self {
+            PartialPrint::Constant(string) => {
+                Value::List(Box::new([boxed::Str::new(ehx, &string).into()]), None)
+            }
+            PartialPrint::SimplifiedArgs(args) => Value::List(args, None),
+        }
+    }
+}
+
+/// Partially pretty prints an arg list value
+///
+/// If partial printing isn't possible or isn't an improvement over the original arg list, `None`
+/// will be returned.
+pub fn partial_pretty_print(
+    ehx: &mut EvalHirCtx,
+    b: &mut Builder,
+    span: Span,
+    arg_list_value: &Value,
+) -> Option<PartialPrint> {
+    let mut list_iter = arg_list_value.try_sized_list_iter()?;
+    let original_arg_count = list_iter.len();
+
+    if original_arg_count < 2 {
+        // Nothing we can do to simplify this further
+        return None;
+    }
+
+    // Accumulates our string literal
+    let mut literal_acc = String::new();
+    let mut simplified_args: Vec<Value> = vec![];
+
+    while let Some(value) = list_iter.next(b, span) {
+        match value_to_const(ehx, &value) {
+            Some(boxed) => {
+                let mut output: Vec<u8> = vec![];
+                arret_runtime_syntax::writer::pretty_print_boxed(&mut output, ehx, boxed);
+
+                literal_acc.push_str(
+                    std::str::from_utf8(&output)
+                        .expect("pretty printed invalid UTF-8 during partial print"),
+                );
+            }
+            None => {
+                if !literal_acc.is_empty() {
+                    simplified_args.push(boxed::Str::new(ehx, &literal_acc).into());
+                    literal_acc.clear();
+                }
+
+                simplified_args.push(value);
+            }
+        };
+    }
+
+    if simplified_args.is_empty() {
+        Some(PartialPrint::Constant(literal_acc))
+    } else {
+        // Push on the end of the accumulator
+        if !literal_acc.is_empty() {
+            simplified_args.push(boxed::Str::new(ehx, &literal_acc).into());
+        }
+
+        if simplified_args.len() < original_arg_count {
+            Some(PartialPrint::SimplifiedArgs(
+                simplified_args.into_boxed_slice(),
+            ))
+        } else {
+            // Didn't improve anything
+            None
+        }
+    }
+}

--- a/compiler/mir/intrinsic/print.rs
+++ b/compiler/mir/intrinsic/print.rs
@@ -1,32 +1,24 @@
 use arret_syntax::span::Span;
 
 use crate::mir::builder::Builder;
-use crate::mir::error::{Error, Result};
+use crate::mir::error::Result;
 use crate::mir::eval_hir::EvalHirCtx;
 use crate::mir::intrinsic::BuildOutcome;
 use crate::mir::value::Value;
 
-use crate::mir::intrinsic::partial_print::{partial_pretty_print, PartialPrint};
+use crate::mir::intrinsic::partial_print::partial_pretty_print;
 
-pub fn panics(
+// `print!`, `println!` & `print-str`
+pub fn print(
     ehx: &mut EvalHirCtx,
     b: &mut Builder,
     span: Span,
     arg_list_value: &Value,
 ) -> Result<BuildOutcome> {
-    use crate::mir::ops::*;
-
     match partial_pretty_print(ehx, b, span, arg_list_value) {
-        // Can simplify this to a single MIR opt
-        Some(PartialPrint::Constant(message)) => {
-            b.push(span, OpKind::Panic(message));
-            Err(Error::Diverged)
-        }
-        // Still contains variables. Simplify the arguments.
         Some(partial_print) => Ok(BuildOutcome::SimplifiedArgs(
             partial_print.into_arg_list_value(ehx),
         )),
-        // Declined to partial print
         None => Ok(BuildOutcome::None),
     }
 }


### PR DESCRIPTION
This expands the existing `panic` intrinsic to:

1. Allow simplifying args instead of only replacing with a constant.
   This is targeted at reducing the amount of LLVM IR we produce for our
   unit tests via `assert-eq!` and `assert-ne!`

2. Extend the optimisation to `print!`, `println!` and `print-str`.

   These only support simplifying args as we have no MIR op or compiler
   support function for printing a constant string.